### PR TITLE
Update directory and extensions

### DIFF
--- a/cmd/flag_types.go
+++ b/cmd/flag_types.go
@@ -101,7 +101,7 @@ func (w *workingDirectory) Type() string {
 
 func findRootDirectory(startPath string) (string, error) {
 	logger.Trace().Msgf("Searching for root directory starting at %s", startPath)
-	dataPath := path.Join("data")
+	dataPath := path.Join("regex-assembly")
 	currentPath := startPath
 	// root directory only will have a separator as the last rune
 	for currentPath[len(currentPath)-1] != filepath.Separator {

--- a/cmd/regex.go
+++ b/cmd/regex.go
@@ -31,9 +31,9 @@ func createRegexCommand() *cobra.Command {
 		Use:   "regex",
 		Short: "Commands that process regular expressions",
 		Long: `The commands in this group all interact with regular expressions.
-For example, they generate regular expressions from data files, update regular expressions
+For example, they generate regular expressions from regex-assembly files, update regular expressions
 in rule files, or compare the regular expressions in rule files against what would be
-generated from the current data file.`,
+generated from the current regex-assembly file.`,
 	}
 
 }
@@ -72,8 +72,8 @@ func parseRuleId(idAndChainOffset string) error {
 		return errors.New("failed to match chain offset. Value must not be larger than 255")
 	}
 
-	if !strings.HasSuffix(fileName, ".data") {
-		fileName += ".data"
+	if !strings.HasSuffix(fileName, ".ra") {
+		fileName += ".ra"
 	}
 
 	ruleValues.id = id

--- a/cmd/regex_compare.go
+++ b/cmd/regex_compare.go
@@ -46,9 +46,9 @@ This command is mainly used for debugging.
 It prints regular expressions in fixed sized chunks and detects the
 first change.
 You can use this command to quickly check whether any rules are out of
-sync with their data file.
+sync with their regex-assembly file.
 
-RULE_ID is the ID of the rule, e.g., 932100, or the data file name.
+RULE_ID is the ID of the rule, e.g., 932100, or the regex-assembly file name.
 If the rule is a chained rule, RULE_ID must be specified with the
 offset of the chain from the chain starter rule. For example, to
 generate a second level chained rule, RULE_ID would be 932100-chain2.`,
@@ -88,7 +88,7 @@ generate a second level chained rule, RULE_ID would be 932100-chain2.`,
 func buildCompareCommand() {
 	regexCmd.AddCommand(compareCmd)
 	compareCmd.Flags().BoolP("all", "a", false, `Instead of supplying a RULE_ID, you can tell the script to
-compare all rules from their data files`)
+compare all rules from their regex-assembly files`)
 }
 
 func rebuildCompareCommand() {
@@ -110,7 +110,7 @@ func performCompare(processAll bool, ctx *processors.Context) {
 				return err
 			}
 
-			if path.Ext(dirEntry.Name()) == ".data" {
+			if path.Ext(dirEntry.Name()) == ".ra" {
 				subs := regex.RuleIdFileNameRegex.FindAllStringSubmatch(dirEntry.Name(), -1)
 				if subs == nil {
 					// continue
@@ -164,7 +164,7 @@ func processRegexForCompare(ruleId string, chainOffset uint8, regex string, ctxt
 	}
 
 	filePath := matches[0]
-	logger.Debug().Msgf("Processing data file %s", filePath)
+	logger.Debug().Msgf("Processing regex-assembly file %s", filePath)
 
 	currentRegex := readCurrentRegex(filePath, ruleId, chainOffset)
 	return compareRegex(filePath, ruleId, chainOffset, regex, currentRegex)

--- a/cmd/regex_compare_test.go
+++ b/cmd/regex_compare_test.go
@@ -38,7 +38,7 @@ func (s *compareTestSuite) SetupTest() {
 	s.NoError(err)
 	s.tempDir = tempDir
 
-	s.dataDir = path.Join(s.tempDir, "data")
+	s.dataDir = path.Join(s.tempDir, "regex-assembly")
 	err = os.MkdirAll(s.dataDir, fs.ModePerm)
 	s.NoError(err)
 
@@ -57,7 +57,7 @@ func TestRunCompareTestSuite(t *testing.T) {
 }
 
 func (s *compareTestSuite) TestCompare_NormalRuleId() {
-	s.writeDataFile("123456.data", "")
+	s.writeDataFile("123456.ra", "")
 	s.writeRuleFile("123456", `SecRule... "@rx regex" \\`+"\nid:123456")
 	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "compare", "123456"})
 	cmd, _ := rootCmd.ExecuteC()
@@ -81,8 +81,8 @@ func (s *compareTestSuite) TestCompare_AllFlag() {
 id:123456
 SecRule... "@rx oldbar" \
 id:123457`)
-	s.writeDataFile("123456.data", "foo")
-	s.writeDataFile("123457.data", "bar")
+	s.writeDataFile("123456.ra", "foo")
+	s.writeDataFile("123457.ra", "bar")
 	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "compare", "--all"})
 	cmd, _ := rootCmd.ExecuteC()
 

--- a/cmd/regex_format.go
+++ b/cmd/regex_format.go
@@ -38,16 +38,16 @@ func init() {
 func createFormatCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "format [RULE_ID | INCLUDE_NAME]",
-		Short: "Format one or more regular expression data files",
-		Long: `Format one or more reguler expression data files.
+		Short: "Format one or more regular expression regex-assembly files",
+		Long: `Format one or more reguler expression regex-assembly files.
 
-RULE_ID is the ID of the rule, e.g., 932100, or the data file name.
+RULE_ID is the ID of the rule, e.g., 932100, or the regex-assembly file name.
 If the rule is a chained rule, RULE_ID must be specified with the
 offset of the chain from the chain starter rule. For example, to
 generate a second level chained rule, RULE_ID would be 932100-chain2.
 
-INCLUDE_NAME is the name of the a file in the "include" directory.
-These files are also data files but don't follow the same naming
+INCLUDE_NAME is the name of the file in the "include" directory, without the extension.
+These files are also regex-assembly files but don't follow the same naming
 scheme, as they don't correspond to any particular rule.`,
 		Args: cobra.MatchAll(cobra.MaximumNArgs(1), func(cmd *cobra.Command, args []string) error {
 			allFlag := cmd.Flags().Lookup("all")
@@ -72,7 +72,7 @@ scheme, as they don't correspond to any particular rule.`,
 			} else {
 				filename := args[0]
 				if path.Ext(filename) == "" {
-					filename += ".data"
+					filename += ".ra"
 				}
 				filePath := path.Join(ctxt.RootContext().IncludeDir(), filename)
 				if err = parseRuleId(filename); err == nil {
@@ -115,7 +115,7 @@ func processAll(ctxt *processors.Context) error {
 			return nil
 		}
 
-		if path.Ext(d.Name()) == ".data" {
+		if path.Ext(d.Name()) == ".ra" {
 			return processFile(filePath, ctxt)
 		}
 		return nil

--- a/cmd/regex_format_test.go
+++ b/cmd/regex_format_test.go
@@ -26,7 +26,7 @@ func (s *formatTestSuite) SetupTest() {
 	s.NoError(err)
 	s.tempDir = tempDir
 
-	s.dataDir = path.Join(s.tempDir, "data")
+	s.dataDir = path.Join(s.tempDir, "regex-assembly")
 	err = os.MkdirAll(s.dataDir, fs.ModePerm)
 	s.NoError(err)
 
@@ -45,7 +45,7 @@ func TestRunFormatTestSuite(t *testing.T) {
 }
 
 func (s *formatTestSuite) TestFormat_NormalRuleId() {
-	s.writeDataFile("123456.data", "")
+	s.writeDataFile("123456.ra", "")
 	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
 	cmd, _ := rootCmd.ExecuteC()
 
@@ -57,7 +57,7 @@ func (s *formatTestSuite) TestFormat_NormalRuleId() {
 }
 
 func (s *formatTestSuite) TestFormat_NormalIncludeName() {
-	s.writeIncludeFile("shell-data.data", "")
+	s.writeIncludeFile("shell-data.ra", "")
 	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "shell-data"})
 	cmd, _ := rootCmd.ExecuteC()
 
@@ -91,7 +91,7 @@ func (s *formatTestSuite) TestFormat_Dash() {
 }
 
 func (s *formatTestSuite) TestFormat_TrimsTabs() {
-	s.writeDataFile("123456.data", `line1	
+	s.writeDataFile("123456.ra", `line1	
 	line2`)
 	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
 	_, err := rootCmd.ExecuteC()
@@ -100,12 +100,12 @@ func (s *formatTestSuite) TestFormat_TrimsTabs() {
 	expected := `line1	
 line2
 `
-	output := s.readDataFile("123456.data")
+	output := s.readDataFile("123456.ra")
 	s.Equal(expected, output)
 }
 
 func (s *formatTestSuite) TestFormat_TrimsSpaces() {
-	s.writeDataFile("123456.data", `line1    
+	s.writeDataFile("123456.ra", `line1    
     line2`)
 	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
 	_, err := rootCmd.ExecuteC()
@@ -114,12 +114,12 @@ func (s *formatTestSuite) TestFormat_TrimsSpaces() {
 	expected := `line1    
 line2
 `
-	output := s.readDataFile("123456.data")
+	output := s.readDataFile("123456.ra")
 	s.Equal(expected, output)
 }
 
 func (s *formatTestSuite) TestFormat_IndentsAssembleBlock() {
-	s.writeDataFile("123456.data", `##!> assemble
+	s.writeDataFile("123456.ra", `##!> assemble
     		line
 ##!<`)
 	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
@@ -130,12 +130,12 @@ func (s *formatTestSuite) TestFormat_IndentsAssembleBlock() {
   line
 ##!<
 `
-	output := s.readDataFile("123456.data")
+	output := s.readDataFile("123456.ra")
 	s.Equal(expected, output)
 }
 
 func (s *formatTestSuite) TestFormat_IndentsNestedAssembleBlocks() {
-	s.writeDataFile("123456.data", `            ##!> assemble
+	s.writeDataFile("123456.ra", `            ##!> assemble
     		line
 	   ##!> assemble
 	               ##!=> output
@@ -170,12 +170,12 @@ func (s *formatTestSuite) TestFormat_IndentsNestedAssembleBlocks() {
   ##!<
 ##!<
 `
-	output := s.readDataFile("123456.data")
+	output := s.readDataFile("123456.ra")
 	s.Equal(expected, output)
 }
 
 func (s *formatTestSuite) TestFormat_EndOfFileHasNewLineAfterNoNewLine() {
-	s.writeDataFile("123456.data", `##!> assemble
+	s.writeDataFile("123456.ra", `##!> assemble
     		line
 ##!<`)
 	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
@@ -186,12 +186,12 @@ func (s *formatTestSuite) TestFormat_EndOfFileHasNewLineAfterNoNewLine() {
   line
 ##!<
 `
-	output := s.readDataFile("123456.data")
+	output := s.readDataFile("123456.ra")
 	s.Equal(expected, output)
 }
 
 func (s *formatTestSuite) TestFormat_EndOfFileHasNewLineAfterOneNewLine() {
-	s.writeDataFile("123456.data", `##!> assemble
+	s.writeDataFile("123456.ra", `##!> assemble
     		line
 ##!<
 `)
@@ -203,12 +203,12 @@ func (s *formatTestSuite) TestFormat_EndOfFileHasNewLineAfterOneNewLine() {
   line
 ##!<
 `
-	output := s.readDataFile("123456.data")
+	output := s.readDataFile("123456.ra")
 	s.Equal(expected, output)
 }
 
 func (s *formatTestSuite) TestFormat_EndOfFileHasNewLineAfterTwoNewLines() {
-	s.writeDataFile("123456.data", `##!> assemble
+	s.writeDataFile("123456.ra", `##!> assemble
     		line
 ##!<
 
@@ -221,23 +221,23 @@ func (s *formatTestSuite) TestFormat_EndOfFileHasNewLineAfterTwoNewLines() {
   line
 ##!<
 `
-	output := s.readDataFile("123456.data")
+	output := s.readDataFile("123456.ra")
 	s.Equal(expected, output)
 }
 
 func (s *formatTestSuite) TestFormat_EndOfFileHasNewLineIfEmpty() {
-	s.writeDataFile("123456.data", "")
+	s.writeDataFile("123456.ra", "")
 	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.NoError(err)
 
 	expected := "\n"
-	output := s.readDataFile("123456.data")
+	output := s.readDataFile("123456.ra")
 	s.Equal(expected, output)
 }
 
 func (s *formatTestSuite) TestFormat_DoesNotRemoveEmptyLines() {
-	s.writeDataFile("123456.data", `        
+	s.writeDataFile("123456.ra", `        
 	
 ##!> assemble
       
@@ -256,12 +256,12 @@ func (s *formatTestSuite) TestFormat_DoesNotRemoveEmptyLines() {
 
 ##!<
 `
-	output := s.readDataFile("123456.data")
+	output := s.readDataFile("123456.ra")
 	s.Equal(expected, output)
 }
 
 func (s *formatTestSuite) TestFormat_DoesNotRemoveComments() {
-	s.writeDataFile("123456.data", `
+	s.writeDataFile("123456.ra", `
 ##! a comment	
 ##!> assemble
 ##! a comment	
@@ -280,12 +280,12 @@ func (s *formatTestSuite) TestFormat_DoesNotRemoveComments() {
   ##! a comment	
 ##!<
 `
-	output := s.readDataFile("123456.data")
+	output := s.readDataFile("123456.ra")
 	s.Equal(expected, output)
 }
 
 func (s *formatTestSuite) TestFormat_OnlyIndentsAssembleProcessor() {
-	s.writeDataFile("123456.data", `##!> assemble
+	s.writeDataFile("123456.ra", `##!> assemble
 ##!> include bart
 ##!> assemble
 ##!+ i
@@ -310,12 +310,12 @@ func (s *formatTestSuite) TestFormat_OnlyIndentsAssembleProcessor() {
 
 ##!<
 `
-	output := s.readDataFile("123456.data")
+	output := s.readDataFile("123456.ra")
 	s.Equal(expected, output)
 }
 
 func (s *formatTestSuite) TestFormat_FormatsProcessors() {
-	s.writeDataFile("123456.data", `##!>assemble
+	s.writeDataFile("123456.ra", `##!>assemble
 ##!> include 	   bart
 ##!>       	 cmdline  	windows
 ##!> define 	homer   	simpson 
@@ -332,7 +332,7 @@ func (s *formatTestSuite) TestFormat_FormatsProcessors() {
   ##!<
 ##!<
 `
-	output := s.readDataFile("123456.data")
+	output := s.readDataFile("123456.ra")
 	s.Equal(expected, output)
 }
 

--- a/cmd/regex_generate.go
+++ b/cmd/regex_generate.go
@@ -25,12 +25,12 @@ func init() {
 func createGenerateCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "generate RULE_ID | -",
-		Short: "Generate regular expression from a data file",
-		Long: `Generate regular expression from a data file.
+		Short: "Generate regular expression from a regex-assembly file",
+		Long: `Generate regular expression from a regex-assembly file.
 This command is mainly used for quick debugging.
 It prints the generated regular expression to stdout.
 
-RULE_ID is the ID of the rule, e.g., 932100, or the data file name.
+RULE_ID is the ID of the rule, e.g., 932100, or the regex-assembly file name.
 If the rule is a chained rule, RULE_ID must be specified with the
 offset of the chain from the chain starter rule. For example, to
 generate a second level chained rule, RULE_ID would be 932100-chain2.
@@ -70,7 +70,7 @@ from stdin.`,
 				logger.Trace().Msgf("Reading from %s", filePath)
 				input, err = os.ReadFile(filePath)
 				if err != nil {
-					logger.Fatal().Err(err).Msgf("Failed to read data file %s", filePath)
+					logger.Fatal().Err(err).Msgf("Failed to read regex-assembly file %s", filePath)
 				}
 			}
 			assembly, err := assembler.Run(string(input))

--- a/cmd/regex_generate_test.go
+++ b/cmd/regex_generate_test.go
@@ -25,7 +25,7 @@ func (s *generateTestSuite) SetupTest() {
 	s.NoError(err)
 	s.tempDir = tempDir
 
-	s.dataDir = path.Join(s.tempDir, "data")
+	s.dataDir = path.Join(s.tempDir, "regex-assembly")
 	err = os.MkdirAll(s.dataDir, fs.ModePerm)
 	s.NoError(err)
 }
@@ -40,7 +40,7 @@ func TestRunGenerateTestSuite(t *testing.T) {
 }
 
 func (s *generateTestSuite) TestGenerate_NormalRuleId() {
-	s.writeDatafile("123456.data", "")
+	s.writeDatafile("123456.ra", "")
 	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "generate", "123456"})
 	cmd, _ := rootCmd.ExecuteC()
 

--- a/cmd/regex_test.go
+++ b/cmd/regex_test.go
@@ -27,7 +27,7 @@ func (s *regexTestSuite) SetupTest() {
 	s.NoError(err)
 	s.tempDir = tempDir
 
-	s.dataDir = path.Join(s.tempDir, "data")
+	s.dataDir = path.Join(s.tempDir, "regex-assembly")
 	err = os.MkdirAll(s.dataDir, fs.ModePerm)
 	s.NoError(err)
 
@@ -46,49 +46,49 @@ func TestRunRegexTestSuite(t *testing.T) {
 }
 
 func (s *regexTestSuite) TestRegex_ParseRuleId() {
-	s.writeDataFile("123456.data", "")
+	s.writeDataFile("123456.ra", "")
 	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "generate", "123456"})
 	_, err := rootCmd.ExecuteC()
 
 	s.NoError(err, "failed to execute rootCmd")
 	s.Equal("123456", ruleValues.id)
-	s.Equal("123456.data", ruleValues.fileName)
+	s.Equal("123456.ra", ruleValues.fileName)
 	s.Equal(uint8(0), ruleValues.chainOffset)
 	s.False(ruleValues.useStdin)
 }
 
 func (s *regexTestSuite) TestRegex_ParseRuleIdAndChainOffset() {
-	s.writeDataFile("123456-chain19.data", "")
+	s.writeDataFile("123456-chain19.ra", "")
 	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "generate", "123456-chain19"})
 	_, err := rootCmd.ExecuteC()
 
 	s.NoError(err, "failed to execute rootCmd")
 	s.Equal("123456", ruleValues.id)
-	s.Equal("123456-chain19.data", ruleValues.fileName)
+	s.Equal("123456-chain19.ra", ruleValues.fileName)
 	s.Equal(uint8(19), ruleValues.chainOffset)
 	s.False(ruleValues.useStdin)
 }
 
 func (s *regexTestSuite) TestRegex_ParseRuleIdAndChainOffsetAndFileName() {
-	s.writeDataFile("123456-chain255.data", "")
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "generate", "123456-chain255.data"})
+	s.writeDataFile("123456-chain255.ra", "")
+	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "generate", "123456-chain255.ra"})
 	_, err := rootCmd.ExecuteC()
 
 	s.NoError(err, "failed to execute rootCmd")
 	s.Equal("123456", ruleValues.id)
-	s.Equal("123456-chain255.data", ruleValues.fileName)
+	s.Equal("123456-chain255.ra", ruleValues.fileName)
 	s.Equal(uint8(255), ruleValues.chainOffset)
 	s.False(ruleValues.useStdin)
 }
 
 func (s *regexTestSuite) TestRegex_ParseRuleIdAndFileName() {
-	s.writeDataFile("123456.data", "")
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "generate", "123456.data"})
+	s.writeDataFile("123456.ra", "")
+	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "generate", "123456.ra"})
 	_, err := rootCmd.ExecuteC()
 
 	s.NoError(err, "failed to execute rootCmd")
 	s.Equal("123456", ruleValues.id)
-	s.Equal("123456.data", ruleValues.fileName)
+	s.Equal("123456.ra", ruleValues.fileName)
 	s.Equal(uint8(0), ruleValues.chainOffset)
 	s.False(ruleValues.useStdin)
 }

--- a/cmd/regex_update.go
+++ b/cmd/regex_update.go
@@ -38,7 +38,7 @@ func createUpdateCommand() *cobra.Command {
 This command will generate regulare expressions from the data
 files and update the associated rule.
 
-RULE_ID is the ID of the rule, e.g., 932100, or the data file name.
+RULE_ID is the ID of the rule, e.g., 932100, or the regex-assembly file name.
 If the rule is a chained rule, RULE_ID must be specified with the
 offset of the chain from the chain starter rule. For example, to
 generate a second level chained rule, RULE_ID would be 932100-chain2.`,
@@ -78,7 +78,7 @@ generate a second level chained rule, RULE_ID would be 932100-chain2.`,
 func buildUpdateCommand() {
 	regexCmd.AddCommand(updateCmd)
 	updateCmd.Flags().BoolP("all", "a", false, `Instead of supplying a RULE_ID, you can tell the script to
-update all rules from their data files`)
+update all rules from their regex-assembly files`)
 }
 
 func rebuildUpdateCommand() {
@@ -98,7 +98,7 @@ func performUpdate(processAll bool, ctx *processors.Context) {
 				return err
 			}
 
-			if !dirEntry.IsDir() && path.Ext(dirEntry.Name()) == ".data" {
+			if !dirEntry.IsDir() && path.Ext(dirEntry.Name()) == ".ra" {
 				subs := regex.RuleIdFileNameRegex.FindAllStringSubmatch(dirEntry.Name(), -1)
 				if subs == nil {
 					// continue
@@ -143,7 +143,7 @@ func runAssemble(filePath string, ctx *processors.Context) string {
 		logger.Trace().Msgf("Reading from %s", filePath)
 		input, err = os.ReadFile(filePath)
 		if err != nil {
-			logger.Fatal().Err(err).Msgf("Failed to read data file %s", filePath)
+			logger.Fatal().Err(err).Msgf("Failed to read regex-assembly file %s", filePath)
 		}
 	}
 	assembly, err := assembler.Run(string(input))

--- a/cmd/regex_update_test.go
+++ b/cmd/regex_update_test.go
@@ -27,7 +27,7 @@ func (s *updateTestSuite) SetupTest() {
 	s.NoError(err)
 	s.tempDir = tempDir
 
-	s.dataDir = path.Join(s.tempDir, "data")
+	s.dataDir = path.Join(s.tempDir, "regex-assembly")
 	err = os.MkdirAll(s.dataDir, fs.ModePerm)
 	s.NoError(err)
 
@@ -46,7 +46,7 @@ func TestRunUpdateTestSuite(t *testing.T) {
 }
 
 func (s *updateTestSuite) TestUpdate_NormalRuleId() {
-	s.writeDataFile("123456.data", "")
+	s.writeDataFile("123456.ra", "")
 	s.writeRuleFile("123456", `SecRule "@rx regex" \\`+"\nid:123456")
 	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "update", "123456"})
 	cmd, _ := rootCmd.ExecuteC()
@@ -102,8 +102,8 @@ func (s *updateTestSuite) TestUpdate_DashReturnsError() {
 }
 
 func (s *updateTestSuite) TestUpdate_UpdatesAllWithAllFlag() {
-	s.writeDataFile("123456.data", "homer")
-	s.writeDataFile("123457.data", "simpson")
+	s.writeDataFile("123456.ra", "homer")
+	s.writeDataFile("123457.ra", "simpson")
 	s.writeRuleFile("123456", `SecRule ARGS "@rx regex1" \
 	"id:123456"
 SecRule ARGS "@rx regex2" \
@@ -125,7 +125,7 @@ SecRule ARGS '@rx regex3" \
 }
 
 func (s *updateTestSuite) TestUpdate_UpdatesInverseRx() {
-	s.writeDataFile("123456.data", "homer")
+	s.writeDataFile("123456.ra", "homer")
 	s.writeRuleFile("123456", `SecRule ARGS "!@rx regex1" \
 	"id:123456"`)
 	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "update", "--all"})
@@ -139,7 +139,7 @@ func (s *updateTestSuite) TestUpdate_UpdatesInverseRx() {
 }
 
 func (s *updateTestSuite) TestUpdate_UpdatesChainedRule() {
-	s.writeDataFile("123456-chain1.data", "homer")
+	s.writeDataFile("123456-chain1.ra", "homer")
 	s.writeRuleFile("123456", `SecRule ARGS "@rx regex1" \
 	"id:123456, \
 	chain"

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -30,7 +30,7 @@ func (s *rootTestSuite) SetupTest() {
 	s.NoError(err)
 	s.tempDir = tempDir
 
-	s.dataDir = path.Join(s.tempDir, "data")
+	s.dataDir = path.Join(s.tempDir, "regex-assembly")
 	err = os.MkdirAll(s.dataDir, fs.ModePerm)
 	s.NoError(err)
 }
@@ -64,7 +64,7 @@ func (s *rootTestSuite) TestRoot_LogLevelDefault() {
 }
 
 func (s *rootTestSuite) TestRoot_LogLevelChanged() {
-	s.writeDataFile("123456.data", "")
+	s.writeDataFile("123456.ra", "")
 	rootCmd.SetArgs([]string{"-d", s.tempDir, "--log-level", "debug", "regex", "generate", "123456"})
 	cmd, _ := rootCmd.ExecuteC()
 
@@ -76,7 +76,7 @@ func (s *rootTestSuite) TestRoot_LogLevelChanged() {
 }
 
 func (s *rootTestSuite) TestRoot_LogLevelInvalidShouldBeDefault() {
-	s.writeDataFile("123456.data", "")
+	s.writeDataFile("123456.ra", "")
 	rootCmd.SetArgs([]string{"-d", s.tempDir, "--log-level", "bizarre", "regex", "generate", "123456"})
 	cmd, _ := rootCmd.ExecuteC()
 
@@ -88,7 +88,7 @@ func (s *rootTestSuite) TestRoot_LogLevelInvalidShouldBeDefault() {
 }
 
 func (s *rootTestSuite) TestRoot_LogLevelAllowedAnywhere() {
-	s.writeDataFile("123456.data", "")
+	s.writeDataFile("123456.ra", "")
 	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "generate", "--log-level", "debug", "123456"})
 	cmd, _ := rootCmd.ExecuteC()
 
@@ -100,7 +100,7 @@ func (s *rootTestSuite) TestRoot_LogLevelAllowedAnywhere() {
 }
 
 func (s *rootTestSuite) TestRoot_AbsoluteWorkingDirectory() {
-	s.writeDataFile("123456.data", "")
+	s.writeDataFile("123456.ra", "")
 	rootCmd.SetArgs([]string{"--directory", s.tempDir, "regex", "generate", "123456"})
 	cmd, _ := rootCmd.ExecuteC()
 
@@ -116,7 +116,7 @@ func (s *rootTestSuite) TestRoot_RelativeWorkingDirectory() {
 	cwd, err := os.Getwd()
 	s.NoError(err)
 	parentCwd := path.Dir(cwd)
-	err = os.MkdirAll(path.Join(parentCwd, "testDir", "data"), fs.ModePerm)
+	err = os.MkdirAll(path.Join(parentCwd, "testDir", "regex-assembly"), fs.ModePerm)
 	s.NoError(err)
 	defer os.RemoveAll(path.Join(parentCwd, "testDir"))
 

--- a/cmd/util_renumber_tests_test.go
+++ b/cmd/util_renumber_tests_test.go
@@ -26,7 +26,7 @@ func (s *renumberTestsTestSuite) SetupTest() {
 	s.NoError(err)
 	s.tempDir = tempDir
 
-	dataDir := path.Join(s.tempDir, "data")
+	dataDir := path.Join(s.tempDir, "regex-assembly")
 	err = os.MkdirAll(dataDir, fs.ModePerm)
 	s.NoError(err)
 

--- a/context/context.go
+++ b/context/context.go
@@ -15,8 +15,8 @@ func New(rootDir string) *Context {
 	return &Context{
 		rootDirectory:                rootDir,
 		rulesDirectory:               rootDir + "/rules",
-		dataFilesDirectory:           rootDir + "/data",
-		includeFilesDirectory:        rootDir + "/data/include",
+		dataFilesDirectory:           rootDir + "/regex-assembly",
+		includeFilesDirectory:        rootDir + "/regex-assembly/include",
 		regressionTestFilesDirectory: rootDir + "/tests/regression/tests",
 	}
 }

--- a/regex/definitions.go
+++ b/regex/definitions.go
@@ -56,9 +56,9 @@ var RuleRxRegex = regexp.MustCompile(`(.*"!?@rx ).*(" \\)`)
 // SecRuleRegex matches any SecRule line.
 var SecRuleRegex = regexp.MustCompile(`\s*SecRule`)
 
-// RuleIdFileNameRegex matches the rule ID in a data file name (<id>.data).
+// RuleIdFileNameRegex matches the rule ID in a regex-assembly file name (<id>.ra).
 // The rule ID is captured in group 1, the optional extension in group 2.
-var RuleIdFileNameRegex = regexp.MustCompile(`^(\d{6})(?:-chain(\d+))?(?:\.data)?$`)
+var RuleIdFileNameRegex = regexp.MustCompile(`^(\d{6})(?:-chain(\d+))?(?:\.ra)?$`)
 
 // TestTitleRegex matches any test_title line in test YAML files (test_title: "<title>").
 // Everything up to the value of the test title is captured in group 1.

--- a/regex/parser/parser.go
+++ b/regex/parser/parser.go
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package parser implements the parsing logic to obtain the sequence of inputs ready for processing.
-// The two main thing it will do is to parse a data file and recursively solve all `includes` first, then
-// substitute all definitions where neccesary.
+// The two main thing it will do is to parse a regex-assembly file and recursively solve all `includes` first, then
+// substitute all definitions where necessary.
 package parser
 
 import (
@@ -201,8 +201,8 @@ func (p *Parser) parseLine(line string) ParsedLine {
 func includeFile(rootParser *Parser, includeName string) (*bytes.Buffer, int) {
 	filename := includeName
 	logger.Trace().Msgf("reading include file: %v", filename)
-	if path.Ext(filename) != ".data" {
-		filename += ".data"
+	if path.Ext(filename) != ".ra" {
+		filename += ".ra"
 	}
 
 	// check if filename has an absolute path

--- a/regex/parser/parser_test.go
+++ b/regex/parser/parser_test.go
@@ -102,12 +102,12 @@ func (s *parserIncludeTestSuite) SetupTest() {
 	s.tempDir, err = os.MkdirTemp("", "include-tests")
 	s.NoError(err)
 
-	s.includeDir = path.Join(s.tempDir, "data", "include")
+	s.includeDir = path.Join(s.tempDir, "regex-assembly", "include")
 	err = os.MkdirAll(s.includeDir, fs.ModePerm)
 	s.NoError(err)
 
 	s.ctx = processors.NewContext(s.tempDir)
-	s.includeFile, err = os.Create(path.Join(s.includeDir, "test.data"))
+	s.includeFile, err = os.Create(path.Join(s.includeDir, "test.ra"))
 	s.NoError(err, "couldn't create %s file", s.includeFile.Name())
 }
 
@@ -230,13 +230,13 @@ func (s *parserMultiIncludeTestSuite) SetupSuite() {
 	s.NoError(err)
 	s.tempDir = tempDir
 
-	s.includeDir = path.Join(s.tempDir, "data", "include")
+	s.includeDir = path.Join(s.tempDir, "regex-assembly", "include")
 	err = os.MkdirAll(s.includeDir, fs.ModePerm)
 	s.NoError(err)
 
 	s.ctx = processors.NewContext(s.tempDir)
 	for i := 0; i < 4; i++ {
-		file, err := os.Create(path.Join(s.includeDir, fmt.Sprintf("multi-include-%d.data", i)))
+		file, err := os.Create(path.Join(s.includeDir, fmt.Sprintf("multi-include-%d.ra", i)))
 		s.NoError(err, "couldn't create %s file", file.Name())
 		if i == 0 {
 			// Only the initial include goes to the reader
@@ -310,13 +310,13 @@ func (s *parserIncludeWithDefinitions) SetupSuite() {
 	s.NoError(err)
 	s.tempDir = tempDir
 
-	s.includeDir = path.Join(s.tempDir, "data", "include")
+	s.includeDir = path.Join(s.tempDir, "regex-assembly", "include")
 	err = os.MkdirAll(s.includeDir, fs.ModePerm)
 	s.NoError(err)
 
 	s.ctx = processors.NewContext(s.tempDir)
 	for i := 0; i < 4; i++ {
-		file, err := os.Create(path.Join(s.tempDir, fmt.Sprintf("multi-definitions-%d.data", i)))
+		file, err := os.Create(path.Join(s.tempDir, fmt.Sprintf("multi-definitions-%d.ra", i)))
 		s.NoError(err, "couldn't create %s file", file.Name())
 		if i == 0 {
 			// Only the initial include goes to the reader

--- a/regex/processors/assemble_test.go
+++ b/regex/processors/assemble_test.go
@@ -52,7 +52,7 @@ func (s *assembleTestSuite) TestNewAssemble() {
 
 	s.NotNil(assemble)
 	s.Equal(assemble.proc.ctx.RootContext().RootDir(), s.tempDir)
-	s.Equal(assemble.proc.ctx.RootContext().DataDir(), s.tempDir+"/data")
+	s.Equal(assemble.proc.ctx.RootContext().DataDir(), s.tempDir+"/regex-assembly")
 }
 
 func (s *assembleTestSuite) TestAssemble_MultipleLines() {


### PR DESCRIPTION
- regexp-assembly files extension was renamed to `.ra`.
- `data` directory was renamed as `regexp-assembly`

Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>