### PR TITLE
fix: fix regex for finding regex in rules

### DIFF
--- a/cmd/regex_compare.go
+++ b/cmd/regex_compare.go
@@ -207,7 +207,7 @@ func readCurrentRegex(filePath string, ruleId string, chainOffset uint8) string 
 	if len(found) == 0 {
 		logger.Fatal().Msgf("Failed to find rule %s in %s", ruleId, filePath)
 	}
-	return found[0][1]
+	return found[0][2]
 }
 
 func compareRegex(filePath string, ruleId string, chainOffset uint8, generatedRegex string, currentRegex string) error {

--- a/cmd/regex_update.go
+++ b/cmd/regex_update.go
@@ -210,7 +210,7 @@ func updateRegex(filePath string, ruleId string, chainOffset uint8, newRegex str
 	if len(found) == 0 {
 		logger.Fatal().Msgf("Failed to find rule %s in %s", ruleId, filePath)
 	}
-	updatedLine := found[0][1] + newRegex + found[0][2]
+	updatedLine := found[0][1] + newRegex + found[0][3]
 	lines[index] = []byte(updatedLine)
 
 	err = os.WriteFile(filePath, bytes.Join(lines, []byte("\n")), fs.ModePerm)

--- a/regex/definitions.go
+++ b/regex/definitions.go
@@ -51,7 +51,7 @@ var AssembleOutputRegex = regexp.MustCompile(`^\s*##!=>\s*(.*)$`)
 // RuleRxRegex matches a full SecRule line with @rx.
 // Everything up to the start of the regular expression is captured in group 1,
 // the end of the line after the regular expression is captured in group 2.
-var RuleRxRegex = regexp.MustCompile(`(.*"!?@rx ).*(" \\)`)
+var RuleRxRegex = regexp.MustCompile(`(.*"!?@rx )(.*)(" \\)`)
 
 // SecRuleRegex matches any SecRule line.
 var SecRuleRegex = regexp.MustCompile(`\s*SecRule`)


### PR DESCRIPTION
I've tried to add a test to verify that compare works as it should but I failed to make zerolog use a different output. It seems impossible to change the root logger, it can only be duplicated (I even tried to use hooks). We'll need to fix that some other time.