### PR TITLE
fix: correct output order of assemble processor

### DIFF
--- a/regex/operators/assembler_test.go
+++ b/regex/operators/assembler_test.go
@@ -919,3 +919,49 @@ func (s *assemblerTestSuite) TestAssemble_DollarRemainsDollarWithSflag() {
 	s.NoError(err)
 	s.Equal("(?s)a|b$", output)
 }
+
+func (s *assemblerTestSuite) TestAssemble_ComplexAppendWithAlternation() {
+	contents := `##!> assemble
+  _prop-start_
+  ##!=< js-prop-start
+##!<
+
+##!> assemble
+  _prop-finish_
+  ##!=< js-prop-finish
+##!<
+
+
+##!> assemble
+  access
+  ##!=< process-funcs
+##!<
+
+##!> assemble
+  env
+  ##!=< process-props
+##!<
+
+##! "process" payloads
+##!> assemble
+  process
+  ##!=>
+
+  ##!> assemble
+    ##!=> js-prop-start
+    ##!> assemble
+	##!=> process-funcs
+    ##!<
+    ##!> assemble
+      ##!=> process-props
+    ##!<
+    ##!=> js-prop-finish
+  ##!<
+##!<`
+	assembler := NewAssembler(s.ctx)
+
+	output, err := assembler.Run(contents)
+
+	s.NoError(err)
+	s.Equal("process_prop-start_(?:access|env)_prop-finish_", output)
+}

--- a/regex/processors/assemble.go
+++ b/regex/processors/assemble.go
@@ -125,6 +125,12 @@ func (a *Assemble) append(identifier string) error {
 			return err
 		}
 	} else {
+		// Append lines that aren't yet in the output
+		err := a.append("")
+		if err != nil {
+			return err
+		}
+
 		stored, ok := a.proc.ctx.stash[identifier]
 		if !ok {
 			return fmt.Errorf("no entry in the stash for name '%s'", identifier)
@@ -132,7 +138,7 @@ func (a *Assemble) append(identifier string) error {
 		logger.Debug().Msgf("Appending stored expression at %s", identifier)
 		logger.Trace().Msgf("Expression stored at %s is %s", identifier, stored)
 
-		_, err := a.output.WriteString(stored)
+		_, err = a.output.WriteString(stored)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When mixing output of stored expressions and alternations, alternations will no longer be appended at the end but at the correct position, i.e., before the append directive.