### PR TITLE
fix: improve test renumbering

### DIFF
--- a/cmd/regex_format.go
+++ b/cmd/regex_format.go
@@ -117,7 +117,7 @@ scheme, as they don't correspond to any particular rule.`,
 func buildFormatCommand() {
 	regexCmd.AddCommand(formatCmd)
 	formatCmd.PersistentFlags().BoolP("all", "a", false, `Instead of supplying a RULE_ID, you can tell the script to
-format all data files (both regular and include files)`)
+format all assembly files (both regular and include files)`)
 	formatCmd.Flags().BoolP("check", "c", false, `Do not write changes, simply report on files that would be formatted`)
 }
 
@@ -156,11 +156,12 @@ func processAll(ctxt *processors.Context, checkOnly bool) error {
 		logger.Error().Err(err).Msg("failed to walk directories")
 		return err
 	}
-	if failed && rootValues.output == gitHub {
-		fmt.Println("::error::All assembly files need to be properly formatted.",
-			"Please run `crs-toolchain regex format --all")
+	if failed {
+		if rootValues.output == gitHub {
+			fmt.Println("::error::All assembly files need to be properly formatted.",
+				"Please run `crs-toolchain regex format --all")
+		}
 		return &UnformattedFileError{}
-
 	}
 	return nil
 }

--- a/cmd/regex_format_test.go
+++ b/cmd/regex_format_test.go
@@ -75,7 +75,7 @@ func (s *formatTestSuite) TestFormat_NoArgument() {
 	s.EqualError(err, "expected RULE_ID, INCLUDE_NAME, or flag, found nothing")
 }
 
-func (s *formatTestSuite) TestFormat_ArumentAndAllFlag() {
+func (s *formatTestSuite) TestFormat_ArgumentAndAllFlag() {
 	rootCmd.SetArgs([]string{"regex", "format", "shell-data", "--all"})
 	_, err := rootCmd.ExecuteC()
 

--- a/cmd/util_renumber_tests.go
+++ b/cmd/util_renumber_tests.go
@@ -4,6 +4,11 @@
 package cmd
 
 import (
+	"errors"
+	"fmt"
+	"path"
+	"path/filepath"
+
 	"github.com/spf13/cobra"
 
 	"github.com/coreruleset/crs-toolchain/context"
@@ -20,12 +25,43 @@ func init() {
 func createRenumberTestsCommand() *cobra.Command {
 
 	return &cobra.Command{
-		Use:   "renumber-tests",
-		Short: "Renumber all CRS tests, so that they are sequential in every file",
-		Args:  cobra.MaximumNArgs(0),
-		Run: func(cmd *cobra.Command, args []string) {
+		Use: "renumber-tests RULE_ID",
+		Short: `Renumber all CRS tests, so that they are sequential in every file.
+
+RULE_ID is the ID of the rule, e.g., 932100, or the test file name.`,
+		Args: cobra.MatchAll(cobra.MaximumNArgs(1), func(cmd *cobra.Command, args []string) error {
+			allFlag := cmd.Flags().Lookup("all")
+			if !allFlag.Changed && len(args) == 0 {
+				return errors.New("expected RULE_ID, or flag, found nothing")
+			} else if allFlag.Changed && len(args) > 0 {
+				return errors.New("expected RULE_ID, or flag, found multiple")
+			} else if len(args) == 1 && args[0] == "-" {
+				return errors.New("invalid argument '-'")
+			}
+
+			return nil
+		}),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			checkOnly, err := cmd.Flags().GetBool("check")
+			if err != nil {
+				return err
+			}
+			processAll, err := cmd.Flags().GetBool("all")
+			if err != nil {
+				return err
+			}
 			ctxt := context.New(rootValues.workingDirectory.String())
-			util.RenumberTests(ctxt)
+			renumberer := util.NewTestRenumberer()
+			if processAll {
+				return renumberer.RenumberTests(checkOnly, rootValues.output == gitHub, ctxt)
+			}
+
+			filenameArg := args[0]
+			filePath, err := parseFilePath(filenameArg, ctxt)
+			if err != nil {
+				return err
+			}
+			return renumberer.RenumberTest(filePath, checkOnly, ctxt)
 		},
 	}
 
@@ -33,6 +69,9 @@ func createRenumberTestsCommand() *cobra.Command {
 
 func buildRenumberTestsCommand() {
 	utilCmd.AddCommand(renumberTestsCommand)
+	renumberTestsCommand.PersistentFlags().BoolP("all", "a", false, `Instead of supplying a RULE_ID, you can tell the script to
+renumber all test files`)
+	renumberTestsCommand.Flags().BoolP("check", "c", false, `Do not write changes, simply report on files that would be renumbered`)
 }
 
 func rebuildRenumberTestsCommand() {
@@ -42,4 +81,23 @@ func rebuildRenumberTestsCommand() {
 
 	renumberTestsCommand = createRenumberTestsCommand()
 	buildRenumberTestsCommand()
+}
+
+func parseFilePath(ruleOrFileName string, ctxt *context.Context) (string, error) {
+	// We have no guarantee that the extension will be `.yaml`, it, so
+	// try to find the file and get the actual name from the file system.
+	extension := path.Ext(ruleOrFileName)
+	ruleOrFileName = ruleOrFileName[:len(ruleOrFileName)-len(extension)]
+	candidates, err := filepath.Glob(path.Join(ctxt.RegressionTestsDir(), ruleOrFileName) + ".*")
+	if err != nil {
+		return "", err
+	}
+	if len(candidates) == 0 {
+		return "", fmt.Errorf("no test file found for argument %s", ruleOrFileName)
+	}
+
+	if len(candidates) > 1 {
+		return "", fmt.Errorf("found multiple test files matching argument %s: %v", ruleOrFileName, candidates)
+	}
+	return candidates[0], nil
 }

--- a/cmd/util_renumber_tests_test.go
+++ b/cmd/util_renumber_tests_test.go
@@ -10,12 +10,37 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+
+	"github.com/coreruleset/crs-toolchain/util"
 )
 
 type renumberTestsTestSuite struct {
 	suite.Suite
 	tempDir  string
 	testsDir string
+}
+
+func (s *renumberTestsTestSuite) writeTestFile(filename string, contents string) {
+	err := os.WriteFile(path.Join(s.testsDir, filename), []byte(contents), fs.ModePerm)
+	s.NoError(err)
+}
+
+func (s *renumberTestsTestSuite) readTestFile(filename string) string {
+	contents, err := os.ReadFile(path.Join(s.testsDir, filename))
+	s.NoError(err)
+	return string(contents)
+}
+
+func (s *renumberTestsTestSuite) captureStdout() *os.File {
+	read, write, err := os.Pipe()
+	s.NoError(err)
+
+	realStdout := os.Stdout
+	os.Stdout = write
+	s.T().Cleanup(func() {
+		os.Stdout = realStdout
+	})
+	return read
 }
 
 func (s *renumberTestsTestSuite) SetupTest() {
@@ -44,37 +69,87 @@ func TestRunRenumberTestsTestSuite(t *testing.T) {
 	suite.Run(t, new(renumberTestsTestSuite))
 }
 
-func (s *renumberTestsTestSuite) TestRenumberTests() {
-	contents := `---
-	meta:
-	  enabled: true
-	  name: 123456.yaml
-	tests:
-	  - test_title: bapedibupi
-		desc: "test 1"
-	  - test_title: "pine apple"
-		desc: "test 2"`
-	expected := `---
-	meta:
-	  enabled: true
-	  name: 123456.yaml
-	tests:
-	  - test_title: 123456-1
-		desc: "test 1"
-	  - test_title: 123456-2
-		desc: "test 2"
-`
-	filePath := path.Join(s.testsDir, "123456.yaml")
-	err := os.WriteFile(filePath, []byte(contents), fs.ModePerm)
+func (s *renumberTestsTestSuite) TestRenumberTests_WithYaml() {
+	s.writeTestFile("123456.yaml", "test_title: homer")
+	rootCmd.SetArgs([]string{"-d", s.tempDir, "util", "renumber-tests", "123456"})
+	_, err := rootCmd.ExecuteC()
 	s.NoError(err)
 
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "util", "renumber-tests"})
-	cmd, err := rootCmd.ExecuteC()
+	actual := s.readTestFile("123456.yaml")
+	s.Equal("test_title: 123456-1\n", actual)
+}
+
+func (s *renumberTestsTestSuite) TestRenumberTests_WithYml() {
+	s.writeTestFile("123456.yml", "test_title: homer")
+	rootCmd.SetArgs([]string{"-d", s.tempDir, "util", "renumber-tests", "123456"})
+	_, err := rootCmd.ExecuteC()
 	s.NoError(err)
+
+	actual := s.readTestFile("123456.yml")
+	s.Equal("test_title: 123456-1\n", actual)
+}
+
+func (s *renumberTestsTestSuite) TestRenumberTests_NormalRuleIdWith() {
+	s.writeTestFile("123456.yaml", "")
+	rootCmd.SetArgs([]string{"-d", s.tempDir, "util", "renumber-tests", "123456"})
+	cmd, _ := rootCmd.ExecuteC()
+
 	s.Equal("renumber-tests", cmd.Name())
 
-	actualContents, err := os.ReadFile(filePath)
+	args := cmd.Flags().Args()
+	s.Len(args, 1)
+	s.Equal("123456", args[0])
+}
+
+func (s *renumberTestsTestSuite) TestRenumberTests_NoArgument() {
+	rootCmd.SetArgs([]string{"util", "renumber-tests"})
+	_, err := rootCmd.ExecuteC()
+
+	s.EqualError(err, "expected RULE_ID, or flag, found nothing")
+}
+
+func (s *renumberTestsTestSuite) TestRenumberTests_ArgumentAndAllFlag() {
+	rootCmd.SetArgs([]string{"util", "renumber-tests", "123456", "--all"})
+	_, err := rootCmd.ExecuteC()
+
+	s.EqualError(err, "expected RULE_ID, or flag, found multiple")
+}
+
+func (s *renumberTestsTestSuite) TestRenumberTests_Dash() {
+	rootCmd.SetArgs([]string{"-d", s.tempDir, "util", "renumber-tests", "-"})
+	_, err := rootCmd.ExecuteC()
+
+	s.EqualError(err, "invalid argument '-'")
+}
+
+func (s *renumberTestsTestSuite) TestRenumberTests_CheckOnly() {
+	contents := "test_title: homer"
+	s.writeTestFile("123456.yaml", contents)
+	rootCmd.SetArgs([]string{"-d", s.tempDir, "util", "renumber-tests", "-c", "123456"})
+	_, err := rootCmd.ExecuteC()
+
+	s.EqualError(err, "Tests are not properly numbered")
+
+	actual := s.readTestFile("123456.yaml")
+	s.Equal(contents, actual)
+}
+
+func (s *renumberTestsTestSuite) TestRenumberTests_GitHubOutput() {
+	read := s.captureStdout()
+
+	contents := "test_title: homer"
+	s.writeTestFile("123456.yaml", contents)
+	rootCmd.SetArgs([]string{"-d", s.tempDir, "util", "renumber-tests", "-cao", "github"})
+	_, err := rootCmd.ExecuteC()
+
+	s.ErrorIs(err, &util.TestNumberingError{})
+
+	buffer := make([]byte, 1024)
+	_, err = read.Read(buffer)
 	s.NoError(err)
 
-	s.Equal(expected, string(actualContents))
+	output := string(buffer)
+	s.Contains(output, "::warning::Test file not properly numbered")
+	s.Contains(output, "::error::")
+	s.Contains(output, "Please run `crs-toolchain util renumber-tests --all`")
 }

--- a/cmd/util_renumber_tests_test.go
+++ b/cmd/util_renumber_tests_test.go
@@ -62,7 +62,8 @@ func (s *renumberTestsTestSuite) TestRenumberTests() {
 	  - test_title: 123456-1
 		desc: "test 1"
 	  - test_title: 123456-2
-		desc: "test 2"`
+		desc: "test 2"
+`
 	filePath := path.Join(s.testsDir, "123456.yaml")
 	err := os.WriteFile(filePath, []byte(contents), fs.ModePerm)
 	s.NoError(err)

--- a/regex/definitions.go
+++ b/regex/definitions.go
@@ -56,9 +56,14 @@ var RuleRxRegex = regexp.MustCompile(`(.*"!?@rx )(.*)(" \\)`)
 // SecRuleRegex matches any SecRule line.
 var SecRuleRegex = regexp.MustCompile(`\s*SecRule`)
 
-// RuleIdFileNameRegex matches the rule ID in a regex-assembly file name (<id>.ra).
-// The rule ID is captured in group 1, the optional extension in group 2.
+// RuleIdFileNameRegex matches the rule ID in a regex-assembly file name (<id>-<chain>.ra).
+// The rule ID is captured in group 1, the optional chain offset in group2,
+// and the optional extension in group 3.
 var RuleIdFileNameRegex = regexp.MustCompile(`^(\d{6})(?:-chain(\d+))?(?:\.ra)?$`)
+
+// RuleIdTestFileNameRegex matches the rule ID in a test file name (<id>.yaml).
+// The rule ID is captured in group 1, the optional extension in group 2.
+var RuleIdTestFileNameRegex = regexp.MustCompile(`^(\d{6})(?:\.ya?ml)?$`)
 
 // TestTitleRegex matches any test_title line in test YAML files (test_title: "<title>").
 // Everything up to the value of the test title is captured in group 1.

--- a/util/renumber_tests.go
+++ b/util/renumber_tests.go
@@ -45,6 +45,11 @@ func RenumberTests(ctxt *context.Context) {
 
 func processFile(filePath string) error {
 	ruleId := path.Base(filePath)[0:6]
+	if !regex.RuleIdFileNameRegex.MatchString(ruleId) {
+		// Skip other files
+		return nil
+	}
+
 	logger.Info().Msgf("Processing %s", ruleId)
 
 	contents, err := os.ReadFile(filePath)
@@ -87,7 +92,5 @@ func processYaml(ruleId string, contents []byte) ([]byte, error) {
 	}
 
 	writer.Flush()
-	outputBytes := output.Bytes()
-	// remove the superfluous newline character
-	return outputBytes[:len(outputBytes)-1], nil
+	return output.Bytes(), nil
 }

--- a/util/renumber_tests_test.go
+++ b/util/renumber_tests_test.go
@@ -29,6 +29,62 @@ tests:
   - test_title: bapedibupi
     desc: "test 1"
   - test_title: "pine apple"
+    desc: "test 2"
+`
+	expected := `---
+meta:
+  enabled: true
+  name: 123456.yaml
+tests:
+  - test_title: 123456-1
+    desc: "test 1"
+  - test_title: 123456-2
+    desc: "test 2"
+`
+	out, err := NewTestRenumberer().processYaml("123456", []byte(contents))
+	s.NoError(err)
+
+	s.Equal(expected, string(out))
+}
+
+func (s *renumberTestsTestSuite) TestRenumberTests_RemoveSuperfluousNewLinesAtEof() {
+	contents := `---
+meta:
+  enabled: true
+  name: 123456.yaml
+tests:
+  - test_title: bapedibupi
+    desc: "test 1"
+  - test_title: "pine apple"
+    desc: "test 2"
+
+
+`
+	expected := `---
+meta:
+  enabled: true
+  name: 123456.yaml
+tests:
+  - test_title: 123456-1
+    desc: "test 1"
+  - test_title: 123456-2
+    desc: "test 2"
+`
+	out, err := NewTestRenumberer().processYaml("123456", []byte(contents))
+	s.NoError(err)
+
+	s.Equal(expected, string(out))
+}
+
+func (s *renumberTestsTestSuite) TestRenumberTests_AddMissingNewLineAtEof() {
+	contents := `---
+meta:
+  enabled: true
+  name: 123456.yaml
+tests:
+  - test_title: bapedibupi
+    desc: "test 1"
+  - test_title: "pine apple"
     desc: "test 2"`
 	expected := `---
 meta:
@@ -40,7 +96,36 @@ tests:
   - test_title: 123456-2
     desc: "test 2"
 `
-	out, err := processYaml("123456", []byte(contents))
+	out, err := NewTestRenumberer().processYaml("123456", []byte(contents))
+	s.NoError(err)
+
+	s.Equal(expected, string(out))
+}
+
+func (s *renumberTestsTestSuite) TestRenumberTests_TrimSpaceOnTrailingLines() {
+	contents := `---
+meta:
+  enabled: true
+  name: 123456.yaml
+tests:
+  - test_title: bapedibupi
+    desc: "test 1"
+  - test_title: "pine apple"
+    desc: "test 2"
+     
+       
+   `
+	expected := `---
+meta:
+  enabled: true
+  name: 123456.yaml
+tests:
+  - test_title: 123456-1
+    desc: "test 1"
+  - test_title: 123456-2
+    desc: "test 2"
+`
+	out, err := NewTestRenumberer().processYaml("123456", []byte(contents))
 	s.NoError(err)
 
 	s.Equal(expected, string(out))

--- a/util/renumber_tests_test.go
+++ b/util/renumber_tests_test.go
@@ -38,7 +38,8 @@ tests:
   - test_title: 123456-1
     desc: "test 1"
   - test_title: 123456-2
-    desc: "test 2"`
+    desc: "test 2"
+`
 	out, err := processYaml("123456", []byte(contents))
 	s.NoError(err)
 


### PR DESCRIPTION
- don't remove trailing newline character
- skip other files in the test directories
- add github output
- add check flag to support linting on GitHub
- use same arguments and flags as for all other commands, for consistency