### PR TITLE
Improve Unix shell evasion detection

### DIFF
--- a/regex/operators/assembler_test.go
+++ b/regex/operators/assembler_test.go
@@ -343,7 +343,7 @@ five
 
 	output, err := assembler.Run(contents)
 	s.NoError(err)
-	s.Equal(`f(?:[\"'\[-\x5c]*(?:\$[!#\*\-0-9\?-@_a-\{]*)?\x5c?o[\"'\[-\x5c]*(?:\$[!#\*\-0-9\?-@_a-\{]*)?\x5c?o|our|ive)|b[\"\^]*a[\"\^]*r|one|t(?:wo|hree)`, output)
+	s.Equal(`f(?:[\"'\[-\x5c]*(?:(?:(?:\|\||&&)[\s\v]*)?\$[!#\*\-0-9\?-@_a-\{]*)?\x5c?o[\"'\[-\x5c]*(?:(?:(?:\|\||&&)[\s\v]*)?\$[!#\*\-0-9\?-@_a-\{]*)?\x5c?o|our|ive)|b[\"\^]*a[\"\^]*r|one|t(?:wo|hree)`, output)
 }
 
 func (s *preprocessorsTestSuite) TestNestedPreprocessors() {
@@ -361,7 +361,7 @@ five
 	assembler := NewAssembler(s.ctx)
 	output, err := assembler.Run(contents)
 	s.NoError(err)
-	s.Equal(`f(?:[\"'\[-\x5c]*(?:\$[!#\*\-0-9\?-@_a-\{]*)?\x5c?o[\"'\[-\x5c]*(?:\$[!#\*\-0-9\?-@_a-\{]*)?\x5c?o|our|ive)|b[\"\^]*a[\"\^]*r`, output)
+	s.Equal(`f(?:[\"'\[-\x5c]*(?:(?:(?:\|\||&&)[\s\v]*)?\$[!#\*\-0-9\?-@_a-\{]*)?\x5c?o[\"'\[-\x5c]*(?:(?:(?:\|\||&&)[\s\v]*)?\$[!#\*\-0-9\?-@_a-\{]*)?\x5c?o|our|ive)|b[\"\^]*a[\"\^]*r`, output)
 }
 
 func (s *preprocessorsTestSuite) TestComplexNestedPreprocessors() {
@@ -390,7 +390,7 @@ eight
 
 	output, err := assembler.Run(contents)
 	s.NoError(err)
-	s.Equal(`f(?:[\"'\[-\x5c]*(?:\$[!#\*\-0-9\?-@_a-\{]*)?\x5c?o[\"'\[-\x5c]*(?:\$[!#\*\-0-9\?-@_a-\{]*)?\x5c?o(?:ab|cd|b[\"\^]*a[\"\^]*r)|our|ive)|s(?:ix|even)|eight`, output)
+	s.Equal(`f(?:[\"'\[-\x5c]*(?:(?:(?:\|\||&&)[\s\v]*)?\$[!#\*\-0-9\?-@_a-\{]*)?\x5c?o[\"'\[-\x5c]*(?:(?:(?:\|\||&&)[\s\v]*)?\$[!#\*\-0-9\?-@_a-\{]*)?\x5c?o(?:ab|cd|b[\"\^]*a[\"\^]*r)|our|ive)|s(?:ix|even)|eight`, output)
 }
 
 func (s *definitionsTestSuite) TestDefinition_ReplacesDefinition() {

--- a/regex/processors/cmdline_test.go
+++ b/regex/processors/cmdline_test.go
@@ -31,9 +31,9 @@ func (s *cmdLineTestSuite) TestCmdLine_NewParser() {
 		},
 		cmdType: CmdLineUnix,
 		evasionPatterns: map[EvasionPatterns]string{
-			evasionPattern:        `[\x5c'\"\[]*(?:\$[a-z0-9_@?!#{*-]*)?(?:\x5c)?`,
-			suffixPattern:         `(?:\s|<|>).*`,
-			suffixExpandedCommand: `(?:(?:<|>)|(?:[\w\d._-][\x5c'\"\[]*(?:\$[a-z0-9_@?!#{*-]*)?(?:\x5c)?)+(?:\s|<|>)).*`,
+			evasionPattern:        `[\x5c'\"\[]*(?:(?:(?:\|\||&&)\s*)?\$[a-z0-9_@?!#{*-]*)?\x5c?`,
+			suffixPattern:         `[\s<>,].*`,
+			suffixExpandedCommand: `(?:[<>,]|(?:[\w\d._-][\x5c'\"\[]*(?:(?:(?:\|\||&&)\s*)?\$[a-z0-9_@?!#{*-]*)?\x5c?)+[\s<>,]).*`,
 		},
 	}
 	actual := NewCmdLine(s.ctx, CmdLineUnix)
@@ -48,7 +48,7 @@ func (s *cmdLineTestSuite) TestCmdLine_CmdLineTypeFromString() {
 
 	err = cmd.ProcessLine(`foo`)
 	s.NoError(err)
-	s.Equal(`f[\x5c'\"\[]*(?:\$[a-z0-9_@?!#{*-]*)?(?:\x5c)?o[\x5c'\"\[]*(?:\$[a-z0-9_@?!#{*-]*)?(?:\x5c)?o`, cmd.proc.lines[0])
+	s.Equal(`f[\x5c'\"\[]*(?:(?:(?:\|\||&&)\s*)?\$[a-z0-9_@?!#{*-]*)?\x5c?o[\x5c'\"\[]*(?:(?:(?:\|\||&&)\s*)?\$[a-z0-9_@?!#{*-]*)?\x5c?o`, cmd.proc.lines[0])
 
 	t, err = CmdLineTypeFromString("windows")
 	s.NoError(err)
@@ -71,7 +71,7 @@ func (s *cmdLineTestSuite) TestCmdLine_ProcessLineFoo() {
 	err := cmd.ProcessLine(`foo`)
 
 	s.NoError(err)
-	s.Equal(`f[\x5c'\"\[]*(?:\$[a-z0-9_@?!#{*-]*)?(?:\x5c)?o[\x5c'\"\[]*(?:\$[a-z0-9_@?!#{*-]*)?(?:\x5c)?o`, cmd.proc.lines[0])
+	s.Equal(`f[\x5c'\"\[]*(?:(?:(?:\|\||&&)\s*)?\$[a-z0-9_@?!#{*-]*)?\x5c?o[\x5c'\"\[]*(?:(?:(?:\|\||&&)\s*)?\$[a-z0-9_@?!#{*-]*)?\x5c?o`, cmd.proc.lines[0])
 }
 
 func (s *cmdLineTestSuite) TestCmdLine_ProcessLinePattern() {
@@ -80,7 +80,7 @@ func (s *cmdLineTestSuite) TestCmdLine_ProcessLinePattern() {
 	err := cmd.ProcessLine(`gcc-10.`)
 	s.NoError(err)
 
-	s.Equal(`g[\x5c'\"\[]*(?:\$[a-z0-9_@?!#{*-]*)?(?:\x5c)?c[\x5c'\"\[]*(?:\$[a-z0-9_@?!#{*-]*)?(?:\x5c)?c[\x5c'\"\[]*(?:\$[a-z0-9_@?!#{*-]*)?(?:\x5c)?\-[\x5c'\"\[]*(?:\$[a-z0-9_@?!#{*-]*)?(?:\x5c)?1[\x5c'\"\[]*(?:\$[a-z0-9_@?!#{*-]*)?(?:\x5c)?0[\x5c'\"\[]*(?:\$[a-z0-9_@?!#{*-]*)?(?:\x5c)?\.`, cmd.proc.lines[0])
+	s.Equal(`g[\x5c'\"\[]*(?:(?:(?:\|\||&&)\s*)?\$[a-z0-9_@?!#{*-]*)?\x5c?c[\x5c'\"\[]*(?:(?:(?:\|\||&&)\s*)?\$[a-z0-9_@?!#{*-]*)?\x5c?c[\x5c'\"\[]*(?:(?:(?:\|\||&&)\s*)?\$[a-z0-9_@?!#{*-]*)?\x5c?\-[\x5c'\"\[]*(?:(?:(?:\|\||&&)\s*)?\$[a-z0-9_@?!#{*-]*)?\x5c?1[\x5c'\"\[]*(?:(?:(?:\|\||&&)\s*)?\$[a-z0-9_@?!#{*-]*)?\x5c?0[\x5c'\"\[]*(?:(?:(?:\|\||&&)\s*)?\$[a-z0-9_@?!#{*-]*)?\x5c?\.`, cmd.proc.lines[0])
 }
 
 func (s *cmdLineTestSuite) TestCmdLine_ProcessLineFooWindows() {


### PR DESCRIPTION
Additional detection of:
- hiding empty variables by using logical operators, e.g. `nc&&$b -nlvp 777`
- brace expansion in shells to omit detection of white space separation, e.g., `{n\c,-nlvp,777}`. Note that expansion would require a leading empty string to work, e.g. `""{n\c,-nlvp,777}`, which will be expanded to `nc -nlvp 777`

Improved comments explaining the supported detections