### PR TITLE
fix: properly prefix / suffix includes

### DIFF
--- a/regex/parser/parser.go
+++ b/regex/parser/parser.go
@@ -251,8 +251,21 @@ func mergeFlagsPrefixesSuffixes(target *Parser, source *Parser, out *bytes.Buffe
 	if _, err := out.WriteTo(newOut); err != nil {
 		logger.Fatal().Err(err).Msg("failed to copy output to new buffer")
 	}
+
+	sawNewLine := false
+	if err := out.UnreadByte(); err == nil {
+		lastByte, err := out.ReadByte()
+		if err == nil {
+			sawNewLine = lastByte == 13
+		}
+	}
+	if sawNewLine {
+		newOut.WriteString("\n")
+	}
+	if len(source.Suffixes) > 0 {
+		newOut.WriteString("##!=>\n")
+	}
 	for _, suffix := range source.Suffixes {
-		newOut.WriteString("\n##!=>\n")
 		newOut.WriteString(suffix)
 		newOut.WriteString("\n##!=>\n")
 	}

--- a/regex/parser/parser_test.go
+++ b/regex/parser/parser_test.go
@@ -174,11 +174,8 @@ included regex`, "data regex")
 	actual, _ := parser.Parse(false)
 	expected := bytes.NewBufferString(`##!> assemble
 included regex
-
 ##!=>
 suffix1
-##!=>
-
 ##!=>
 suffix2
 ##!=>
@@ -206,11 +203,8 @@ prefix1
 prefix2
 ##!=>
 included regex
-
 ##!=>
 suffix1
-##!=>
-
 ##!=>
 suffix2
 ##!=>


### PR DESCRIPTION
Do not add superfluous empty lines with output comments. These lines will not run through a parser a second time and thus remain in the output. In the end, those empty lines will produce empty matches `(?:)`.