### PR TITLE
feat: adds build version into executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,10 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+build/
+dist/
+.idea/
+
+# asdf versioning manager
+.tool-versions

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,7 +23,8 @@ var rootValues = struct {
 	configurationFileName configurationFileName
 }{}
 
-func Execute() {
+func Execute(version string) {
+	rootCmd.Version = version
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -4,11 +4,36 @@
 package main
 
 import (
+	"fmt"
+
 	_ "github.com/coreruleset/crs-toolchain/logger"
 
 	"github.com/coreruleset/crs-toolchain/cmd"
 )
 
+// nolint: gochecknoglobals
+var (
+	version = "dev"
+	commit  = ""
+	date    = ""
+	builtBy = ""
+)
+
 func main() {
-	cmd.Execute()
+	cmd.Execute(buildVersion(version, commit, date, builtBy))
+
+}
+
+func buildVersion(version, commit, date, builtBy string) string {
+	var result = version
+	if commit != "" {
+		result = fmt.Sprintf("%s\ncommit: %s", result, commit)
+	}
+	if date != "" {
+		result = fmt.Sprintf("%s\nbuilt at: %s", result, date)
+	}
+	if builtBy != "" {
+		result = fmt.Sprintf("%s\nbuilt by: %s", result, builtBy)
+	}
+	return result
 }


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Embeds version information at build time.

Example:
```
❯ goreleaser build --clean
  • starting build...
  • loading config file                              file=.goreleaser.yml
  • loading environment variables
  • getting and validating git state
    • building...                                    commit=b3179cfa53e761a36b988cb5fd4b9978e6fc9c06 latest tag=v1.3.9
  • parsing tag
  • setting defaults
  • running before hooks
    • running                                        hook=go mod download
  • checking distribution directory
    • cleaning dist
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/crs-toolchain_windows_amd64_v1/crs-toolchain.exe
    • building                                       binary=dist/crs-toolchain_linux_amd64_v1/crs-toolchain
    • building                                       binary=dist/crs-toolchain_darwin_arm64/crs-toolchain
    • building                                       binary=dist/crs-toolchain_linux_arm64/crs-toolchain
    • building                                       binary=dist/crs-toolchain_darwin_amd64_v1/crs-toolchain
    • took: 22s
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • build succeeded after 23s
❯ ./dist/crs-toolchain_darwin_amd64_v1/crs-toolchain --version
crs-toolchain version 1.3.9
commit: b3179cfa53e761a36b988cb5fd4b9978e6fc9c06
built at: 2023-02-12T06:40:05Z
built by: goreleaser
```

Version will be there after we tag (release).

Fixes #65.