### PR TITLE
feat: enable empty string as suffix replacement

### DIFF
--- a/regex/parser/include_except_builder.go
+++ b/regex/parser/include_except_builder.go
@@ -70,7 +70,7 @@ func replaceSuffixes(inputLines *bytes.Buffer, suffixReplacements map[string]str
 			for match, replacement := range suffixReplacements {
 				var found bool
 				entry, found = strings.CutSuffix(entry, match)
-				if found {
+				if found && replacement != `""` {
 					entry += replacement
 				}
 			}

--- a/regex/parser/include_except_test.go
+++ b/regex/parser/include_except_test.go
@@ -211,6 +211,34 @@ no suffix 2
 	s.Equal(expected, actual.String())
 }
 
+func (s *parserIncludeExceptTestSuite) TestIncludeExcept_SuffixReplacements_WithEmptyString() {
+	includePath := s.writeFile(`no suffix1
+suffix with@
+suffix with~
+no suffix 2`,
+		s.includeDir)
+	excludePath := s.writeFile("no suffix1", s.excludeDir)
+	assemblyPath := s.writeFile(
+		fmt.Sprintf(
+			"##!> include-except %s %s -- %s %s %s %s", includePath, excludePath,
+			"@", `""`,
+			"~", `""`),
+		s.assemblyDir)
+
+	assemblyFile, err := os.Open(assemblyPath)
+	s.Require().NoError(err)
+	defer assemblyFile.Close()
+
+	parser := NewParser(s.ctx, assemblyFile)
+	actual, _ := parser.Parse(false)
+	expected := `suffix with
+suffix with
+no suffix 2
+`
+
+	s.Equal(expected, actual.String())
+}
+
 func (s *parserIncludeExceptTestSuite) TestIncludeExcept_MultipleExcludes() {
 	includePath := s.writeFile(`\s*include1
 leave me alone`, s.includeDir)

--- a/regex/parser/include_test.go
+++ b/regex/parser/include_test.go
@@ -155,7 +155,7 @@ no suffix 2
 	s.Equal(expected.String(), actual.String())
 }
 
-func (s *parserIncludeTestSuite) TestParserInclude_SuffixReplacements_WithBacSpacing() {
+func (s *parserIncludeTestSuite) TestParserInclude_SuffixReplacements_WithBadSpacing() {
 	_, err := s.includeFile.WriteString(`no suffix1
 suffix with@
 suffix with~
@@ -171,6 +171,28 @@ no suffix 2`)
 	expected := bytes.NewBufferString(`no suffix1
 suffix with[\s><]
 suffix with[^\s]
+no suffix 2
+`)
+
+	s.Equal(expected.String(), actual.String())
+}
+
+func (s *parserIncludeTestSuite) TestParserInclude_SuffixReplacements_WithEmptyString() {
+	_, err := s.includeFile.WriteString(`no suffix1
+suffix with@
+suffix with~
+no suffix 2`)
+	s.Require().NoError(err, "writing temp include file failed")
+
+	s.reader = strings.NewReader(fmt.Sprintf(
+		"##!> include %s -- %s %s %s %s", s.includeFile.Name(),
+		"@", `""`,
+		"~", `""`))
+	parser := NewParser(s.ctx, s.reader)
+	actual, _ := parser.Parse(false)
+	expected := bytes.NewBufferString(`no suffix1
+suffix with
+suffix with
 no suffix 2
 `)
 


### PR DESCRIPTION
The logic for parsing suffix replacements did not allow for the empty string. This commit remedies that by using `""` as a special literal to mean the empty string.