### PR TITLE
fix: update copyright year in SecRule ver and SecComponentSignature

### DIFF
--- a/chore/update_copyright.go
+++ b/chore/update_copyright.go
@@ -86,10 +86,5 @@ func updateRules(version string, year string, contents []byte) ([]byte, error) {
 		return nil, err
 	}
 	outputBytes := output.Bytes()
-	// if the file was empty, we didn't change anything and we're done
-	if len(outputBytes) == 0 {
-		return outputBytes, nil
-	}
-	// remove the superfluous newline character
-	return outputBytes[:len(outputBytes)-1], nil
+	return outputBytes, nil
 }

--- a/chore/update_copyright.go
+++ b/chore/update_copyright.go
@@ -69,11 +69,14 @@ func updateRules(version string, year string, contents []byte) ([]byte, error) {
 	writer := bufio.NewWriter(output)
 	replaceVersion := fmt.Sprintf("${1}%s", version)
 	replaceYear := fmt.Sprintf("${1}%s${3}", year)
+	replaceSecRuleVersion := fmt.Sprintf("${1}%s", version)
+	replaceSecComponentSignature := fmt.Sprintf("${1}%s", version)
 	for scanner.Scan() {
 		line := scanner.Text()
 		line = regex.CRSVersionRegex.ReplaceAllString(line, replaceVersion)
 		line = regex.CRSCopyrightYearRegex.ReplaceAllString(line, replaceYear)
-
+		line = regex.CRSYearSecRuleVerRegex.ReplaceAllString(line, replaceSecRuleVersion)
+		line = regex.CRSVersionComponentSignatureRegex.ReplaceAllString(line, replaceSecComponentSignature)
 		if _, err := writer.WriteString(line); err != nil {
 			return nil, err
 		}

--- a/chore/update_copyright_test.go
+++ b/chore/update_copyright_test.go
@@ -20,6 +20,7 @@ func TestRunUpdateCopyrightTestsTestSuite(t *testing.T) {
 	suite.Run(t, new(copyrightUpdateTestsTestSuite))
 }
 
+// Test that the function updates the year in the file
 func (s *copyrightUpdateTestsTestSuite) TestUpdateCopyrightTests_SetVersion() {
 	contents := `# ------------------------------------------------------------------------
 # OWASP ModSecurity Core Rule Set ver.4.0.0-rc1
@@ -36,7 +37,8 @@ func (s *copyrightUpdateTestsTestSuite) TestUpdateCopyrightTests_SetVersion() {
 #
 # Ref: https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#wiki-SecComponentSignature
 #
-SecComponentSignature "OWASP_CRS/4.0.0-rc1"`
+SecComponentSignature "OWASP_CRS/4.0.0-rc1"
+`
 	expected := `# ------------------------------------------------------------------------
 # OWASP ModSecurity Core Rule Set ver.9.1.22
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
@@ -52,8 +54,92 @@ SecComponentSignature "OWASP_CRS/4.0.0-rc1"`
 #
 # Ref: https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#wiki-SecComponentSignature
 #
-SecComponentSignature "OWASP_CRS/4.0.0-rc1"`
+SecComponentSignature "OWASP_CRS/9.1.22"
+`
 	out, err := updateRules("9.1.22", "2042", []byte(contents))
+	s.Require().NoError(err)
+
+	s.Equal(expected, string(out))
+}
+
+// Test that the function updates the year in the copyright, in the SecComponentSignature and the SecRule "ver" part
+func (s *copyrightUpdateTestsTestSuite) TestUpdateCopyrightTests_SetYear() {
+	contents := `# ------------------------------------------------------------------------
+# OWASP ModSecurity Core Rule Set ver.4.0.0-rc1
+# Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
+# Copyright (c) 2021-2022 CRS project. All rights reserved.
+#
+# The OWASP ModSecurity Core Rule Set is distributed under
+# Apache Software License (ASL) version 2
+# Please see the enclosed LICENSE file for full details.
+# ------------------------------------------------------------------------
+
+SecRule &TX:crs_setup_version "@eq 0" \
+    "id:901001,\
+    phase:1,\
+    deny,\
+    status:500,\
+    log,\
+    auditlog,\
+    msg:'ModSecurity CRS is deployed without configuration! Please copy the crs-setup.conf.example template to crs-setup.conf, and include the crs-setup.conf file in your webserver configuration before including the CRS rules. See the INSTALL file in the CRS directory for detailed instructions',\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    severity:'CRITICAL'"
+
+# -=[ Rules Version ]=-
+#
+# Rule version data is added to the "Producer" line of Section H of the Audit log:
+#
+# - Producer: ModSecurity for Apache/2.9.1 (http://www.modsecurity.org/); OWASP_CRS/3.1.0.
+#
+# Ref: https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v2.x)#seccomponentsignature
+#
+SecComponentSignature "OWASP_CRS/3.3.5"
+`
+	expected := `# ------------------------------------------------------------------------
+# OWASP ModSecurity Core Rule Set ver.4.99.12
+# Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
+# Copyright (c) 2021-2041 CRS project. All rights reserved.
+#
+# The OWASP ModSecurity Core Rule Set is distributed under
+# Apache Software License (ASL) version 2
+# Please see the enclosed LICENSE file for full details.
+# ------------------------------------------------------------------------
+
+SecRule &TX:crs_setup_version "@eq 0" \
+    "id:901001,\
+    phase:1,\
+    deny,\
+    status:500,\
+    log,\
+    auditlog,\
+    msg:'ModSecurity CRS is deployed without configuration! Please copy the crs-setup.conf.example template to crs-setup.conf, and include the crs-setup.conf file in your webserver configuration before including the CRS rules. See the INSTALL file in the CRS directory for detailed instructions',\
+    ver:'OWASP_CRS/4.99.12',\
+    severity:'CRITICAL'"
+
+# -=[ Rules Version ]=-
+#
+# Rule version data is added to the "Producer" line of Section H of the Audit log:
+#
+# - Producer: ModSecurity for Apache/2.9.1 (http://www.modsecurity.org/); OWASP_CRS/3.1.0.
+#
+# Ref: https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v2.x)#seccomponentsignature
+#
+SecComponentSignature "OWASP_CRS/4.99.12"
+`
+	out, err := updateRules("4.99.12", "2041", []byte(contents))
+	s.Require().NoError(err)
+
+	s.Equal(expected, string(out))
+}
+
+// Test that the function adds a new line when the file does not end with a new line
+func (s *copyrightUpdateTestsTestSuite) TestUpdateCopyrightTests_AddsNewLine() {
+	contents := `# ------------------------------------------------------------------------
+# OWASP ModSecurity Core Rule Set ver.4.0.0-rc1`
+	expected := `# ------------------------------------------------------------------------
+# OWASP ModSecurity Core Rule Set ver.4.99.12
+`
+	out, err := updateRules("4.99.12", "2041", []byte(contents))
 	s.Require().NoError(err)
 
 	s.Equal(expected, string(out))

--- a/magefile.go
+++ b/magefile.go
@@ -18,7 +18,7 @@ import (
 )
 
 var addLicenseVersion = "v1.1.1" // https://github.com/google/addlicense
-var golangCILintVer = "v1.55.2"  // https://github.com/golangci/golangci-lint/releases
+var golangCILintVer = "v1.56.2"  // https://github.com/golangci/golangci-lint/releases
 var gosImportsVer = "v0.3.8"     // https://github.com/rinchsan/gosimports/releases/tag/v0.1.5
 var goGciVer = "v0.10.1"         // https://github.com/daixiang0/gci/releases/tag/v0.8.2
 

--- a/regex/definitions.go
+++ b/regex/definitions.go
@@ -79,9 +79,19 @@ var DefinitionReferenceRegex = regexp.MustCompile(`{{([a-zA-Z0-9-_]+)}}`)
 
 // CRSVersionRegex matches the version contained on every rules file.
 // The version declared on the file is captured in group 1.
-var CRSVersionRegex = regexp.MustCompile(`^(# OWASP ModSecurity Core Rule Set ver\.)(.+)$`)
+var CRSVersionRegex = regexp.MustCompile(`^(# OWASP (ModSecurity Core Rule Set|CRS) ver\.)(.+)$`)
 
 // CRSCopyrightYearRegex matches the version and year range of the copyright text in setup,
 // setup example, and rule files.
 // The matched end year of the copyright year range will be captured in group 1.
-var CRSCopyrightYearRegex = regexp.MustCompile(`^(# Copyright \(c\) 2021-)(\d{4})( Core Rule Set project. All rights reserved.)$`)
+var CRSCopyrightYearRegex = regexp.MustCompile(`^(# Copyright \(c\) 2021-)(\d{4})( (Core Rule Set|CRS) project. All rights reserved.)$`)
+
+// CRSYearSecRuleVerRegex matches the version in the SecRule part of the text, (e.g. ver:'OWASP_CRS/4.0.0')
+// setup example, and rule files.
+// The matched year will be captured in group 1.
+var CRSYearSecRuleVerRegex = regexp.MustCompile(`(ver:'OWASP_CRS/)(\d+\.\d+\.\d+(-rc\d+)?)`)
+
+// CRSVersionComponentSignatureRegex matches the version in the SecComponentSignature part of the text, (e.g. OWASP_CRS/4.0.0-rc1)
+// setup example, and rule files.
+// The matched year will be captured in group 1.
+var CRSVersionComponentSignatureRegex = regexp.MustCompile(`^(SecComponentSignature "OWASP_CRS/)(\d+\.\d+\.\d+(-rc\d+)?)`)


### PR DESCRIPTION
- the `ver:` part of SecRules was not being updated
- update also the `SecComponentSignature`
- check that we add a last newline at EOF, if the file didn't had it

Fixes #114.