### PR TITLE
fix: position indicator at start of line

### DIFF
--- a/cmd/regex_format.go
+++ b/cmd/regex_format.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -261,7 +260,7 @@ func processLine(line []byte, indent int) ([]byte, int, error) {
 		trimmedLine = []byte(fmt.Sprintf("##!$ %s", matches[1]))
 		blockIndent = 0
 	} else if matches := definitionRegex.FindSubmatch(line); matches != nil {
-		trimmedLine = []byte(fmt.Sprintf("##!> define %s %s", matches[1], matches[2]))
+		trimmedLine = []byte(fmt.Sprintf("##!> define %s %s", matches[2], matches[3]))
 	} else if matches := includeRegex.FindSubmatch(line); matches != nil {
 		trimmedLineString := fmt.Sprintf("##!> include %s", matches[1])
 		if len(matches[2]) > 0 {
@@ -325,8 +324,6 @@ func findUpperCaseOnIgnoreCaseFlag(lines []string, iFlag bool) (bool, string) {
 	res := false
 	definition := false
 	message := ""
-	// this definition regex defers from the global one in that it captures the whole line up to the variable value.
-	definitionRegex := regexp.MustCompile(`^(##!>\s*define\s+([a-zA-Z0-9-_]+)\s+)(\S+)\s*$`)
 	// check if the file contains uppercase letters
 	if iFlag {
 		for i, line := range lines {

--- a/cmd/regex_format.go
+++ b/cmd/regex_format.go
@@ -325,21 +325,21 @@ func findUpperCaseOnIgnoreCaseFlag(lines []string, iFlag bool) (bool, string) {
 	message := ""
 	// check if the file contains uppercase letters
 	if iFlag {
-		for number, line := range lines {
+		for _, line := range lines {
 			// ignore line if it starts with the following regex: \s+##!
 			if regex.CommentRegex.MatchString(line) {
 				continue
 			}
-			found := findUppercaseNonEscaped(line)
-			if found > -1 {
+			found, index := findUppercaseNonEscaped(line)
+			if found {
 				// show the column where the uppercase letter was found
 				// for a better visual match, we add equal symbols a and a caret in a line below
 				fill := ""
-				if found > 0 {
-					fill = strings.Repeat("=", found-1)
+				if index > 0 {
+					fill = strings.Repeat("=", index)
 				}
 				res = true
-				message = fmt.Sprintf("\n%s\n%s^ [HERE]\n", lines[number], fill)
+				message = fmt.Sprintf("\n%s\n%s^ [HERE]\n", line, fill)
 				break
 			}
 		}
@@ -347,8 +347,9 @@ func findUpperCaseOnIgnoreCaseFlag(lines []string, iFlag bool) (bool, string) {
 	return res, message
 }
 
-// findUppercaseNonEscaped returns the index of the first uppercase letter that is not escaped
-func findUppercaseNonEscaped(line string) int {
+// findUppercaseNonEscaped finds an uppercase character that is not escaped in a given line
+// returns true if the line contains an uppercase character that is not escaped, and the index of the character
+func findUppercaseNonEscaped(line string) (bool, int) {
 	for i, c := range line {
 		if c >= 'A' && c <= 'Z' {
 			// go back and check if the character is escaped
@@ -365,9 +366,9 @@ func findUppercaseNonEscaped(line string) int {
 				}
 			}
 			if count%2 == 0 {
-				return i
+				return true, i
 			}
 		}
 	}
-	return -1
+	return false, -1
 }

--- a/cmd/regex_format.go
+++ b/cmd/regex_format.go
@@ -213,7 +213,7 @@ func processFile(filePath string, ctxt *processors.Context, checkOnly bool) erro
 		}
 		equalContent := bytes.Equal(currentContents, newContents)
 		if !equalContent || foundUppercase {
-			message = formatMessage("File not properly formatted")
+			message = formatMessage(fmt.Sprintf("File %s not properly formatted", filePath))
 			fmt.Println(message)
 			processFileError = &UnformattedFileError{filePath: filePath}
 		}
@@ -283,7 +283,7 @@ func processLine(line []byte, indent int) ([]byte, int, error) {
 
 func formatMessage(message string) string {
 	if rootValues.output == gitHub {
-		message = "::warning::" + message
+		message = fmt.Sprintf("::warning ::%s\n", message)
 	}
 	return message
 }
@@ -333,7 +333,13 @@ func findUpperCaseOnIgnoreCaseFlag(lines []string, iFlag bool) (bool, string) {
 			found := strings.IndexAny(line, "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
 			if found > -1 {
 				res = true
-				message = fmt.Sprintf("%s\n%s^ [HERE]\n", lines[number], strings.Repeat("=", found-1))
+				// show the column where the uppercase letter was found
+				// for a better visual match, we add equal symbols a and a caret in a line below
+				fill := ""
+				if found > 0 {
+					fill = strings.Repeat("=", found-1)
+				}
+				message = fmt.Sprintf("\n%s\n%s^ [HERE]\n", lines[number], fill)
 			}
 		}
 	}

--- a/cmd/regex_format_test.go
+++ b/cmd/regex_format_test.go
@@ -513,6 +513,25 @@ this is a regex
 	s.Contains(out.String(), "{1,3}[Bb]lah\\n=====^ [HERE]\\n\"}\n")
 }
 
+func (s *formatTestSuite) TestIgnoreCaseFlagWithUppercasePositionIndicator() {
+	// send logs to buffer
+	out := &bytes.Buffer{}
+	log := zerolog.New(out)
+	logger = log.With().Str("component", "parser-test").Logger()
+
+	s.writeDataFile("123456.ra", regexAssemblyStandardHeader+`
+##!+ i
+First letter is uppercase
+`)
+	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "-c", "123456", "-o", "github"})
+
+	_, err := rootCmd.ExecuteC()
+	s.EqualError(err, fmt.Sprintf("File not properly formatted: %s", path.Join(s.dataDir, "123456.ra")))
+
+	s.Contains(out.String(), "File contains uppercase letters, but ignore-case flag is set. Please check your source files.")
+	s.Contains(out.String(), "First letter is uppercase\\n^ [HERE]\\n\"}\n")
+}
+
 func (s *formatTestSuite) writeDataFile(filename string, contents string) {
 	err := os.WriteFile(path.Join(s.dataDir, filename), []byte(contents), fs.ModePerm)
 	s.Require().NoError(err)

--- a/cmd/regex_format_test.go
+++ b/cmd/regex_format_test.go
@@ -510,7 +510,7 @@ this is a regex
 	s.EqualError(err, fmt.Sprintf("File not properly formatted: %s", path.Join(s.dataDir, "123456.ra")))
 
 	s.Contains(out.String(), "File contains uppercase letters, but ignore-case flag is set. Please check your source files.")
-	s.Contains(out.String(), "{1,3}[Bb]lah\\n=====^ [HERE]\\n\"}\n")
+	s.Contains(out.String(), "{1,3}[Bb]lah\\n======^ [HERE]\\n\"}\n")
 }
 
 func (s *formatTestSuite) TestIgnoreCaseFlagWithUppercasePositionIndicator() {

--- a/cmd/regex_format_test.go
+++ b/cmd/regex_format_test.go
@@ -569,6 +569,42 @@ even number of escape sequences should be bad \\\\A\\B
 	s.Contains(out.String(), "even number of escape sequences should be bad")
 }
 
+func (s *formatTestSuite) TestIgnoreCaseFlagWithUppercase_PlusDefinitions() {
+	// send logs to buffer
+	out := &bytes.Buffer{}
+	log := zerolog.New(out)
+	logger = log.With().Str("component", "parser-test").Logger()
+
+	s.writeDataFile("123456.ra", regexAssemblyStandardHeader+`
+##!> define homer simpson
+##!+ i
+multiple escape sequences \A\B\S should be good.
+`)
+	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "-c", "123456", "-o", "github"})
+
+	_, err := rootCmd.ExecuteC()
+	s.Require().NoError(err)
+}
+
+func (s *formatTestSuite) TestIgnoreCaseFlagWithUppercase_PlusDefinitionsWithUppercase() {
+	// send logs to buffer
+	out := &bytes.Buffer{}
+	log := zerolog.New(out)
+	logger = log.With().Str("component", "parser-test").Logger()
+
+	s.writeDataFile("123456.ra", regexAssemblyStandardHeader+`
+##!> define homer No_Bueno
+##!+ i
+multiple escape sequences \A\B\S should be good.
+`)
+	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "-c", "123456", "-o", "github"})
+
+	_, err := rootCmd.ExecuteC()
+	s.EqualError(err, fmt.Sprintf("File not properly formatted: %s", path.Join(s.dataDir, "123456.ra")))
+	s.Contains(out.String(), "File contains uppercase letters, but ignore-case flag is set. Please check your source files.")
+	s.Contains(out.String(), "##!> define homer No_Bueno\\n==================^ [HERE]")
+}
+
 func (s *formatTestSuite) writeDataFile(filename string, contents string) {
 	err := os.WriteFile(path.Join(s.dataDir, filename), []byte(contents), fs.ModePerm)
 	s.Require().NoError(err)

--- a/regex/definitions.go
+++ b/regex/definitions.go
@@ -18,7 +18,7 @@ var IncludeExceptRegex = regexp.MustCompile(`^##!>\s*include-except\s+(\S+)\s*(.
 var DefinitionRegex = regexp.MustCompile(`^##!>\s*define\s+([a-zA-Z0-9-_]+)\s+(\S+)\s*$`)
 
 // CommentRegex matches a comment line (##!, no other directives)
-var CommentRegex = regexp.MustCompile(`^##!(?:[^^$+><=]|$)`)
+var CommentRegex = regexp.MustCompile(`^\s*##!(?:[^^$+><=]|$)`)
 
 // FlagsRegex matches a flags line (##!+ <value>).
 // The value is captured in group 1.

--- a/regex/definitions.go
+++ b/regex/definitions.go
@@ -14,8 +14,9 @@ var IncludeRegex = regexp.MustCompile(`##!>\s*include\s+(\S+)(?:\s*--\s*(.*?))?\
 var IncludeExceptRegex = regexp.MustCompile(`^##!>\s*include-except\s+(\S+)\s*(.*?)(?:\s*--\s*(.*?))?\s*$`)
 
 // DefinitionRegex matches a definition processor line (##! define <name> <value>)
-// The name is captured in group 1, the value in group 2.
-var DefinitionRegex = regexp.MustCompile(`^##!>\s*define\s+([a-zA-Z0-9-_]+)\s+(\S+)\s*$`)
+// Everything up to the value of the definition is captured in group 1.
+// The name is captured in group 2, the value in group 3.
+var DefinitionRegex = regexp.MustCompile(`^(##!>\s*define\s+([a-zA-Z0-9-_]+)\s+)(\S+)\s*$`)
 
 // CommentRegex matches a comment line (##!, no other directives)
 var CommentRegex = regexp.MustCompile(`^\s*##!(?:[^^$+><=]|$)`)

--- a/regex/parser/parser.go
+++ b/regex/parser/parser.go
@@ -206,7 +206,7 @@ func (p *Parser) parseLine(line string) ParsedLine {
 				pl.excludeFileNames = splitArgs(found[2])
 			case definitionPatternName:
 				pl.parsedType = definition
-				pl.definitions = map[string]string{found[1]: found[2]}
+				pl.definitions = map[string]string{found[2]: found[3]}
 			case flagsPatternName:
 				pl.parsedType = flags
 				pl.flags = found[1]


### PR DESCRIPTION
Fixes #118 and #119.

- updated comment regex to match [comments that start with space](https://github.com/coreruleset/coreruleset/blob/6f8675f17f31ebebff664bbee84578f8d0a65703/regex-assembly/941210.ra#L220).
- do not match on character classes, unless we have an odd number of escapes (e.g. `\S` vs. `\\S`, the former is a char class, the latter is an escaped quote followed by uppercase `S`).
- parses definitions for uppercase also.
- added tests for everything.