### PR TITLE
fix: improve group removal step

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/creativeprojects/go-selfupdate v1.3.0
 	github.com/google/uuid v1.6.0
-	github.com/itchyny/rassemble-go v0.1.0
+	github.com/itchyny/rassemble-go v0.1.2
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKe
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/itchyny/rassemble-go v0.1.0 h1:PaH3f4XNlFx2SImEezdREmkW+/w2t3aLZS9xleHEPjY=
-github.com/itchyny/rassemble-go v0.1.0/go.mod h1:3P4ZuUAYUp+hBvdkVPrL/IhiR0U5CLeCLaqREgGJB7c=
+github.com/itchyny/rassemble-go v0.1.2 h1:4Jtms+JnlXJPbBfeXzdgXf/TJnFWilFzA6bXn+ZF6yM=
+github.com/itchyny/rassemble-go v0.1.2/go.mod h1:VWc9FWUhn/1G2gGivJlq+K9toP2ylbKOwO46P/bPZFo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/regex/operators/assembler_test.go
+++ b/regex/operators/assembler_test.go
@@ -1015,3 +1015,48 @@ func (s *assemblerTestSuite) TestAssemble_FlagGroupReplacementWithEscapedParenth
 	s.Require().NoError(err)
 	s.Equal(contents, output)
 }
+
+// regexp/syntax procudes flag groups we don't want. Make sure that
+// Removal of those groups does not remove groups that are semantically
+// relevant, which is the case when the flag group wraps an alternation.
+func (s *assemblerTestSuite) TestAssemble_ReplaceFlagGroupsWithAlternations() {
+	contents := `(?-s:(?s:.)(?i:A|B .))`
+	expected := `.(?:A|B .)`
+	assembler := NewAssembler(s.ctx)
+
+	output, err := assembler.Run(contents)
+
+	s.Require().NoError(err)
+	s.Equal(expected, output)
+}
+
+func (s *assemblerTestSuite) TestAssemble_RemoveOutermostNonMatchingGroup() {
+	contents := `(?:ab|cd)`
+	expected := `ab|cd`
+	assembler := NewAssembler(s.ctx)
+
+	output, err := assembler.Run(contents)
+
+	s.Require().NoError(err)
+	s.Equal(expected, output)
+}
+func (s *assemblerTestSuite) TestAssemble_RemoveOutermostNonMatchingGroup_WithExtraGroup() {
+	contents := `(?:(?:ab|cd))`
+	expected := `ab|cd`
+	assembler := NewAssembler(s.ctx)
+
+	output, err := assembler.Run(contents)
+
+	s.Require().NoError(err)
+	s.Equal(expected, output)
+}
+
+func (s *assemblerTestSuite) TestAssemble_RemoveOutermostNonMatchingGroup_Dont() {
+	contents := `(?:ab|cd)e|fg`
+	assembler := NewAssembler(s.ctx)
+
+	output, err := assembler.Run(contents)
+
+	s.Require().NoError(err)
+	s.Equal(contents, output)
+}

--- a/regex/operators/operators.go
+++ b/regex/operators/operators.go
@@ -6,6 +6,7 @@ package operators
 import (
 	"errors"
 	"io"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 
@@ -15,11 +16,12 @@ import (
 var logger = log.With().Str("component", "operators").Logger()
 
 type Operator struct {
-	name    string
-	details map[string]string
-	lines   []string
-	stats   *Stats
-	ctx     *processors.Context
+	name                          string
+	details                       map[string]string
+	lines                         []string
+	stats                         *Stats
+	ctx                           *processors.Context
+	groupReplacementStringBuilder *strings.Builder
 }
 
 type ProcessorStack struct {

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,6 @@
     "config:base",
     "schedule:weekly"
   ],
-  "ignoreDeps": ["github.com/itchyny/rassemble-go"],
   "packageRules": [
     {
       "groupName": "all non-major dependencies",


### PR DESCRIPTION
This change fixes the issue uncovered with the upgrade to rassemble-go v0.1.1.

- consider alternations when removing flag groups
- handle top level group specially