### PR TITLE
fix: restrict use of evasion modifiers to end of line

### DIFF
--- a/regex/operators/assembler.go
+++ b/regex/operators/assembler.go
@@ -326,11 +326,11 @@ func (o *Operator) findGroupBodyEnd(input string, groupBodyStart int) (int, bool
 		char := input[index]
 		switch char {
 		case '(':
-			if !isEscaped(input, index) {
+			if !regex.IsEscaped(input, index) {
 				parensCounter++
 			}
 		case ')':
-			if !isEscaped(input, index) {
+			if !regex.IsEscaped(input, index) {
 				parensCounter--
 			}
 		case '|':
@@ -341,17 +341,6 @@ func (o *Operator) findGroupBodyEnd(input string, groupBodyStart int) (int, bool
 	}
 
 	return index - 2, hasAlternation
-}
-
-func isEscaped(input string, position int) bool {
-	escapeCounter := 0
-	for backtrackIndex := position - 1; backtrackIndex >= 0; backtrackIndex++ {
-		if input[backtrackIndex] != '\\' {
-			break
-		}
-		escapeCounter++
-	}
-	return escapeCounter%2 != 0
 }
 
 func (a *Operator) startPreprocessor(processorName string, args []string) error {

--- a/regex/processors/cmdline.go
+++ b/regex/processors/cmdline.go
@@ -8,8 +8,9 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/coreruleset/crs-toolchain/v2/regex"
 	"github.com/itchyny/rassemble-go"
+
+	"github.com/coreruleset/crs-toolchain/v2/regex"
 )
 
 const (

--- a/regex/processors/cmdline_test.go
+++ b/regex/processors/cmdline_test.go
@@ -115,3 +115,59 @@ func (s *cmdLineTestSuite) TestCmdLine_ProcessLineFooWindows() {
 
 	s.Equal(`f_av-w_o_av-w_o`, cmd.proc.lines[0])
 }
+
+func (s *cmdLineTestSuite) TestCmdLine_ProcessTildeOnlyAtLineEnd() {
+	cmd := NewCmdLine(s.ctx, CmdLineUnix)
+
+	err := cmd.ProcessLine(`~foo`)
+	s.Require().NoError(err)
+
+	s.Equal(`~_av-u_f_av-u_o_av-u_o`, cmd.proc.lines[0])
+
+	err = cmd.ProcessLine(`f~oo`)
+	s.Require().NoError(err)
+
+	s.Equal(`f_av-u_~_av-u_o_av-u_o`, cmd.proc.lines[1])
+}
+
+func (s *cmdLineTestSuite) TestCmdLine_IgnoreEscapedTildeAtLineEnd() {
+	cmd := NewCmdLine(s.ctx, CmdLineUnix)
+
+	err := cmd.ProcessLine(`\~foo`)
+	s.Require().NoError(err)
+
+	s.Equal(`\_av-u_~_av-u_f_av-u_o_av-u_o`, cmd.proc.lines[0])
+
+	err = cmd.ProcessLine(`foo\~`)
+	s.Require().NoError(err)
+
+	s.Equal(`f_av-u_o_av-u_o_av-u_~`, cmd.proc.lines[1])
+}
+
+func (s *cmdLineTestSuite) TestCmdLine_ProcessAtOnlyAtLineEnd() {
+	cmd := NewCmdLine(s.ctx, CmdLineUnix)
+
+	err := cmd.ProcessLine(`@foo`)
+	s.Require().NoError(err)
+
+	s.Equal(`@_av-u_f_av-u_o_av-u_o`, cmd.proc.lines[0])
+
+	err = cmd.ProcessLine(`f@oo`)
+	s.Require().NoError(err)
+
+	s.Equal(`f_av-u_@_av-u_o_av-u_o`, cmd.proc.lines[1])
+}
+
+func (s *cmdLineTestSuite) TestCmdLine_IgnoreEscapedAtAtLineEnd() {
+	cmd := NewCmdLine(s.ctx, CmdLineUnix)
+
+	err := cmd.ProcessLine(`\@foo`)
+	s.Require().NoError(err)
+
+	s.Equal(`\_av-u_@_av-u_f_av-u_o_av-u_o`, cmd.proc.lines[0])
+
+	err = cmd.ProcessLine(`foo\@`)
+	s.Require().NoError(err)
+
+	s.Equal(`f_av-u_o_av-u_o_av-u_@`, cmd.proc.lines[1])
+}

--- a/regex/utils.go
+++ b/regex/utils.go
@@ -1,0 +1,12 @@
+package regex
+
+func IsEscaped(input string, position int) bool {
+	escapeCounter := 0
+	for backtrackIndex := position - 1; backtrackIndex >= 0; backtrackIndex-- {
+		if input[backtrackIndex] != '\\' {
+			break
+		}
+		escapeCounter++
+	}
+	return escapeCounter%2 != 0
+}

--- a/regex/utils_test.go
+++ b/regex/utils_test.go
@@ -1,0 +1,37 @@
+package regex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type utilsTestSuite struct {
+	suite.Suite
+}
+
+func TestRunUtilsTestSuite(t *testing.T) {
+	suite.Run(t, new(utilsTestSuite))
+}
+
+func (s *utilsTestSuite) TestIsEscaped_NoEscapeSequence() {
+	s.False(IsEscaped("abc", 0))
+	s.False(IsEscaped("abc", 1))
+	s.False(IsEscaped("abc", 2))
+}
+
+func (s *utilsTestSuite) TestIsEscaped_EscapeSequence() {
+	s.False(IsEscaped(`a\bc`, 0))
+	s.False(IsEscaped(`a\bc`, 1))
+	s.True(IsEscaped(`a\bc`, 2))
+	s.False(IsEscaped(`a\bc`, 3))
+}
+
+func (s *utilsTestSuite) TestIsEscaped_IgnoreBackslash() {
+	s.False(IsEscaped(`a\\\bc`, 0))
+	s.False(IsEscaped(`a\\\bc`, 1))
+	s.True(IsEscaped(`a\\\bc`, 2))
+	s.False(IsEscaped(`a\\\bc`, 3))
+	s.True(IsEscaped(`a\\\bc`, 4))
+	s.False(IsEscaped(`a\\\bc`, 5))
+}


### PR DESCRIPTION
Until now, `~` and `@` would be replaced by the evasion suffix regardless of their position in the string, even though the evasion suffix was only ever intended to be used as a suffix. With this commit, `~` and `@` are only treated specially if they occur as the last character on the line.

In addition, it is now possible to escape a terminal `~` or `@` with a backslash. The only limitation is that the toolchain cannot handle a sequence such as `abc\\~`, which would result in `abc\\<suffix>` instead of `abc\<suffix>` because there's no special handling of backslash espaces in general.

Fixes #185