### PR TITLE
fix: incorrect hex representation of Unicode characters (Example: \x2019 instead of \x{2019})

### DIFF
--- a/regex/operators/assembler.go
+++ b/regex/operators/assembler.go
@@ -246,8 +246,11 @@ func (a *Operator) includeVerticalTabInSpaceClass(input string) string {
 func (a *Operator) useHexEscapes(input string) string {
 	var sb strings.Builder
 	for _, char := range input {
-		if char < 32 || char > 126 {
-			sb.WriteString(fmt.Sprintf("\x{%x}", char))
+		if char < 32 {
+			// For control characters (ASCII < 32), use the shorthand hex notation (\xHH).
+			sb.WriteString(fmt.Sprintf("\\x%x", char))
+		} else if char > 126 {
+			sb.WriteString(fmt.Sprintf("\\x{%x}", char))
 		} else {
 			sb.WriteRune(char)
 		}

--- a/regex/operators/assembler.go
+++ b/regex/operators/assembler.go
@@ -247,8 +247,8 @@ func (a *Operator) useHexEscapes(input string) string {
 	var sb strings.Builder
 	for _, char := range input {
 		if char < 32 || char > 126 {
-			sb.WriteString(`\x`)
-			sb.WriteString(fmt.Sprintf("%x", char))
+			sb.WriteString(`\x{`)
+			sb.WriteString(fmt.Sprintf("%x}", char))
 		} else {
 			sb.WriteRune(char)
 		}

--- a/regex/operators/assembler.go
+++ b/regex/operators/assembler.go
@@ -247,8 +247,7 @@ func (a *Operator) useHexEscapes(input string) string {
 	var sb strings.Builder
 	for _, char := range input {
 		if char < 32 || char > 126 {
-			sb.WriteString(`\x{`)
-			sb.WriteString(fmt.Sprintf("%x}", char))
+			sb.WriteString(fmt.Sprintf("\x{%x}", char))
 		} else {
 			sb.WriteRune(char)
 		}

--- a/regex/operators/assembler_test.go
+++ b/regex/operators/assembler_test.go
@@ -354,7 +354,7 @@ func (s *specialCasesTestSuite) TestDoesNotConvertHexEscapesOfNonPrintableCharac
 	s.Equal(`H\x{e2}\x93\x{ab}`, output)
 }
 
-func (s *specialCasesTestSuite) TestHexConversionOfNonPrintableCharacters() {
+func (s *specialCasesTestSuite) TestHexConversionOfNonAsciiCharacters() {
 	contents := `(?:’)`
 	assembler := NewAssembler(s.ctx)
 	output, err := assembler.Run(contents)

--- a/regex/operators/assembler_test.go
+++ b/regex/operators/assembler_test.go
@@ -351,7 +351,15 @@ func (s *specialCasesTestSuite) TestDoesNotConvertHexEscapesOfNonPrintableCharac
 	assembler := NewAssembler(s.ctx)
 	output, err := assembler.Run(contents)
 	s.Require().NoError(err)
-	s.Equal(`H\xe2\x93\xab`, output)
+	s.Equal(`H\x{e2}\x93\x{ab}`, output)
+}
+
+func (s *specialCasesTestSuite) TestHexConversionOfNonPrintableCharacters() {
+	contents := `(?:’)`
+	assembler := NewAssembler(s.ctx)
+	output, err := assembler.Run(contents)
+	s.Require().NoError(err)
+	s.Equal(`\x{2019}`, output)
 }
 
 func (s *specialCasesTestSuite) TestBackslashSReplacesPerlEquivalentCharacterClass() {


### PR DESCRIPTION
Reference Issue: https://github.com/coreruleset/crs-toolchain/issues/221
