### PR TITLE
chore: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+<!-- Please sign your commits: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits -->
+<!-- You don't need to remove these comments, they won't be added to the PR -->
+## what
+
+<!--
+- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
+- Use bullet points to be concise and to the point.
+-->
+
+
+## why
+
+<!--
+- Provide the justifications for the changes (e.g. business case).
+- Describe why these changes were made (e.g. why do these commits fix the problem?)
+- Use bullet points to be concise and to the point.
+-->
+
+
+## references
+
+<!--
+- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
+- Use `closes #123`, if this PR closes a GitHub issue `#123`
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 ## what
 
 <!--
-- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
+- Describe high-level what changed as a result of these commits (i.e. in plain english, what do these changes mean?)
 - Use bullet points to be concise and to the point.
 -->
 
@@ -20,6 +20,6 @@
 ## references
 
 <!--
-- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
+- Link to any supporting GitHub issues or helpful documentation to add some context (e.g. StackOverflow).
 - Use `closes #123`, if this PR closes a GitHub issue `#123`
 -->


### PR DESCRIPTION
## what

- add PR template

## why

- remind people to sign their git commits
- add structure to the description in future PRs