### PR TITLE
fix: sort entries before printing for fp-finder command

### DIFF
--- a/util/fp_finder.go
+++ b/util/fp_finder.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"regexp"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/coreruleset/crs-toolchain/v2/utils"
@@ -142,8 +141,10 @@ func (t *FpFinder) processWords(inputFile []string, dict map[string]struct{}, mi
 	// Filter words not in the dictionary
 	filteredWords := t.filterContent(inputFile, dict, minSize)
 
-	// Sort words alphabetically (case-sensitive)
-	sort.Strings(filteredWords)
+	// Sort words alphabetically (case-insensitive)
+	slices.SortFunc(filteredWords, func(a, b string) int {
+		return strings.Compare(strings.ToLower(a), strings.ToLower(b))
+	})
 
 	// Remove adjacent duplicate words from the sorted list
 	filteredWords = slices.Compact(filteredWords)

--- a/util/fp_finder.go
+++ b/util/fp_finder.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"regexp"
 	"slices"
+	"sort"
 	"strings"
 
 	"github.com/coreruleset/crs-toolchain/v2/utils"
@@ -75,8 +76,11 @@ func (t *FpFinder) FpFinder(inputFilePath string, extendedDictionaryFilePath str
 		logger.Fatal().Err(err).Msg("Failed to load input file")
 	}
 
-	// Filter words not in dictionary, remove duplicates, and sort alphabetically
+	// Filter words not in dictionary
 	filteredWords := t.filterContent(inputFile, dict, minSize)
+
+	// Sort words alphabetically (case-sensitive)
+	sort.Strings(filteredWords)
 
 	// Remove adjacent duplicate words from the sorted list
 	filteredWords = slices.Compact(filteredWords)

--- a/util/fp_finder.go
+++ b/util/fp_finder.go
@@ -76,14 +76,8 @@ func (t *FpFinder) FpFinder(inputFilePath string, extendedDictionaryFilePath str
 		logger.Fatal().Err(err).Msg("Failed to load input file")
 	}
 
-	// Filter words not in dictionary
-	filteredWords := t.filterContent(inputFile, dict, minSize)
-
-	// Sort words alphabetically (case-sensitive)
-	sort.Strings(filteredWords)
-
-	// Remove adjacent duplicate words from the sorted list
-	filteredWords = slices.Compact(filteredWords)
+	// Process words from inputfile, sort the output and remove duplicates
+	filteredWords := t.processWords(inputFile, dict, minSize)
 
 	for _, str := range filteredWords {
 		fmt.Println(str)
@@ -142,6 +136,19 @@ func (t *FpFinder) loadFileContent(path string) ([]string, error) {
 	}
 
 	return content, nil
+}
+
+func (t *FpFinder) processWords(inputFile []string, dict map[string]struct{}, minSize int) []string {
+	// Filter words not in the dictionary
+	filteredWords := t.filterContent(inputFile, dict, minSize)
+
+	// Sort words alphabetically (case-sensitive)
+	sort.Strings(filteredWords)
+
+	// Remove adjacent duplicate words from the sorted list
+	filteredWords = slices.Compact(filteredWords)
+
+	return filteredWords
 }
 
 func (t *FpFinder) filterContent(inputFile []string, dict map[string]struct{}, minSize int) []string {

--- a/util/fp_finder_test.go
+++ b/util/fp_finder_test.go
@@ -38,6 +38,20 @@ func (s *fpFinderTestSuite) TestFpFinder_FilterContent() {
 	s.Equal(expected, result)
 }
 
+func (s *fpFinderTestSuite) TestFpFinder_ProcessWords() {
+	input := []string{"apple", "banana", "orange", "banana", "pear", "#comment", "banana"}
+	dict := map[string]struct{}{
+		"apple":  {},
+		"orange": {},
+	}
+
+	expected := []string{"banana", "pear"}
+
+	result := NewFpFinder().processWords(input, dict, 3)
+
+	s.Equal(expected, result)
+}
+
 func (s *fpFinderTestSuite) TestFpFinder_MergeDictionaries() {
 	a := map[string]struct{}{"apple": {}, "banana": {}}
 	b := map[string]struct{}{"cherry": {}, "date": {}}

--- a/util/fp_finder_test.go
+++ b/util/fp_finder_test.go
@@ -52,6 +52,17 @@ func (s *fpFinderTestSuite) TestFpFinder_ProcessWords() {
 	s.Equal(expected, result)
 }
 
+func (s *fpFinderTestSuite) TestFpFinder_ProcessWords_Sorting() {
+	input := []string{"pear", "Banana", ".hiddenfruit", "kiwi", "banana", "Apple", ".dotfruit"}
+	dict := map[string]struct{}{} // empty dictionary, so no filtering
+
+	expected := []string{".dotfruit", ".hiddenfruit", "Apple", "Banana", "banana", "kiwi", "pear"}
+
+	result := NewFpFinder().processWords(input, dict, 3)
+
+	s.Equal(expected, result)
+}
+
 func (s *fpFinderTestSuite) TestFpFinder_MergeDictionaries() {
 	a := map[string]struct{}{"apple": {}, "banana": {}}
 	b := map[string]struct{}{"cherry": {}, "date": {}}


### PR DESCRIPTION
Seems like I refactored too much with initial PR #219 and inadvertently removed the sorting 😊
This commit will fix it.