### PR TITLE
fix: require exactly one argument to fp-finder command

### DIFF
--- a/cmd/chore_test.go
+++ b/cmd/chore_test.go
@@ -14,7 +14,6 @@ import (
 
 type choreTestSuite struct {
 	suite.Suite
-	tempDir  string
 	dataDir  string
 	rulesDir string
 }
@@ -23,21 +22,12 @@ func (s *choreTestSuite) SetupTest() {
 	rebuildChoreCommand()
 	rebuildChoreUpdateCopyrightCommand()
 
-	tempDir, err := os.MkdirTemp("", "chore-tests")
-	s.Require().NoError(err)
-	s.tempDir = tempDir
-
-	s.dataDir = path.Join(s.tempDir, "regex-assembly")
-	err = os.MkdirAll(s.dataDir, fs.ModePerm)
+	s.dataDir = path.Join(s.T().TempDir(), "regex-assembly")
+	err := os.MkdirAll(s.dataDir, fs.ModePerm)
 	s.Require().NoError(err)
 
-	s.rulesDir = path.Join(s.tempDir, "rules")
+	s.rulesDir = path.Join(s.T().TempDir(), "rules")
 	err = os.Mkdir(s.rulesDir, fs.ModePerm)
-	s.Require().NoError(err)
-}
-
-func (s *choreTestSuite) TearDownTest() {
-	err := os.RemoveAll(s.tempDir)
 	s.Require().NoError(err)
 }
 
@@ -58,7 +48,7 @@ func (s *choreTestSuite) TestChore_RulesFile() {
 
 #
 # This file REQUEST-901-INITIALIZATION.conf initializes the Core Rules`)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "chore", "update-copyright", "-v", "1.2.3", "-y", "1234"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "chore", "update-copyright", "-v", "1.2.3", "-y", "1234"})
 	_, err := rootCmd.ExecuteC()
 
 	s.Require().NoError(err, "failed to execute rootCmd")

--- a/cmd/chore_update_copyright_test.go
+++ b/cmd/chore_update_copyright_test.go
@@ -14,7 +14,6 @@ import (
 
 type choreUpdateCopyrightTestSuite struct {
 	suite.Suite
-	tempDir  string
 	dataDir  string
 	rulesDir string
 }
@@ -23,15 +22,11 @@ func (s *choreUpdateCopyrightTestSuite) SetupTest() {
 	rebuildChoreCommand()
 	rebuildChoreUpdateCopyrightCommand()
 
-	tempDir, err := os.MkdirTemp("", "update-copyright-tests")
-	s.Require().NoError(err)
-	s.tempDir = tempDir
-
-	s.dataDir = path.Join(s.tempDir, "regex-assembly")
-	err = os.MkdirAll(s.dataDir, fs.ModePerm)
+	s.dataDir = path.Join(s.T().TempDir(), "regex-assembly")
+	err := os.MkdirAll(s.dataDir, fs.ModePerm)
 	s.Require().NoError(err)
 
-	s.rulesDir = path.Join(s.tempDir, "rules")
+	s.rulesDir = path.Join(s.T().TempDir(), "rules")
 	err = os.Mkdir(s.rulesDir, fs.ModePerm)
 	s.Require().NoError(err)
 
@@ -49,7 +44,7 @@ func (s *choreUpdateCopyrightTestSuite) SetupTest() {
 # This file REQUEST-901-INITIALIZATION.conf initializes the Core Rules`)
 	s.FileExists(path.Join(s.rulesDir, "TEST-900.conf"))
 
-	s.writeFile(path.Join(s.tempDir, "crs-setup.conf.example"), `# ------------------------------------------------------------------------
+	s.writeFile(path.Join(s.T().TempDir(), "crs-setup.conf.example"), `# ------------------------------------------------------------------------
 # OWASP ModSecurity Core Rule Set ver.4.9.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2022 Core Rule Set project. All rights reserved.
@@ -61,12 +56,7 @@ func (s *choreUpdateCopyrightTestSuite) SetupTest() {
 
 #
 # This file is the crs-setup.conf.example shipped with CRS`)
-	s.FileExists(path.Join(s.tempDir, "crs-setup.conf.example"))
-}
-
-func (s *choreUpdateCopyrightTestSuite) TearDownTest() {
-	err := os.RemoveAll(s.tempDir)
-	s.Require().NoError(err)
+	s.FileExists(path.Join(s.T().TempDir(), "crs-setup.conf.example"))
 }
 
 func TestRunUpdateCopyrightTestSuite(t *testing.T) {
@@ -74,7 +64,7 @@ func TestRunUpdateCopyrightTestSuite(t *testing.T) {
 }
 
 func (s *choreUpdateCopyrightTestSuite) TestUpdateCopyright_Version512() {
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "chore", "update-copyright", "-v", "5.1.2"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "chore", "update-copyright", "-v", "5.1.2"})
 	cmd, _ := rootCmd.ExecuteC()
 
 	s.Equal("update-copyright", cmd.Name())
@@ -85,13 +75,13 @@ func (s *choreUpdateCopyrightTestSuite) TestUpdateCopyright_Version512() {
 	s.Contains(string(contents), "OWASP ModSecurity Core Rule Set ver.5.1.2")
 
 	// check that crs-setup.conf.example was also modified
-	contents, err = os.ReadFile(path.Join(s.tempDir, "crs-setup.conf.example"))
+	contents, err = os.ReadFile(path.Join(s.T().TempDir(), "crs-setup.conf.example"))
 	s.Require().NoError(err)
 	s.Contains(string(contents), "OWASP ModSecurity Core Rule Set ver.5.1.2")
 }
 
 func (s *choreUpdateCopyrightTestSuite) TestUpdateCopyright_Year2100() {
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "chore", "update-copyright", "-y", "2100", "-v", "7.1.22"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "chore", "update-copyright", "-y", "2100", "-v", "7.1.22"})
 	cmd, _ := rootCmd.ExecuteC()
 
 	s.Equal("update-copyright", cmd.Name())
@@ -102,13 +92,13 @@ func (s *choreUpdateCopyrightTestSuite) TestUpdateCopyright_Year2100() {
 	s.Contains(string(contents), "2021-2100")
 
 	// check that crs-setup.conf.example was also modified
-	contents, err = os.ReadFile(path.Join(s.tempDir, "crs-setup.conf.example"))
+	contents, err = os.ReadFile(path.Join(s.T().TempDir(), "crs-setup.conf.example"))
 	s.Require().NoError(err)
 	s.Contains(string(contents), "2021-2100")
 }
 
 func (s *choreUpdateCopyrightTestSuite) TestUpdateCopyright_ErrIfNoVersion() {
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "chore", "update-copyright", "-y", "2222"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "chore", "update-copyright", "-y", "2222"})
 	cmd, err := rootCmd.ExecuteC()
 
 	s.Equal("update-copyright", cmd.Name())
@@ -117,7 +107,7 @@ func (s *choreUpdateCopyrightTestSuite) TestUpdateCopyright_ErrIfNoVersion() {
 }
 
 func (s *choreUpdateCopyrightTestSuite) TestUpdateCopyright_DevRelease() {
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "chore", "update-copyright", "-v", "5.4.3-dev"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "chore", "update-copyright", "-v", "5.4.3-dev"})
 	cmd, _ := rootCmd.ExecuteC()
 
 	s.Equal("update-copyright", cmd.Name())
@@ -129,7 +119,7 @@ func (s *choreUpdateCopyrightTestSuite) TestUpdateCopyright_DevRelease() {
 	s.NotContains(string(contents), "OWASP ModSecurity Core Rule Set ver.5.4.3-dev-dev")
 
 	// check that crs-setup.conf.example was also modified
-	contents, err = os.ReadFile(path.Join(s.tempDir, "crs-setup.conf.example"))
+	contents, err = os.ReadFile(path.Join(s.T().TempDir(), "crs-setup.conf.example"))
 	s.Require().NoError(err)
 	s.Contains(string(contents), "OWASP ModSecurity Core Rule Set ver.5.4.3-dev")
 	s.NotContains(string(contents), "OWASP ModSecurity Core Rule Set ver.5.4.3-dev-dev")

--- a/cmd/regex_compare_test.go
+++ b/cmd/regex_compare_test.go
@@ -16,7 +16,6 @@ import (
 
 type compareTestSuite struct {
 	suite.Suite
-	tempDir  string
 	dataDir  string
 	rulesDir string
 }
@@ -47,21 +46,12 @@ func (s *compareTestSuite) captureStdout() *os.File {
 
 func (s *compareTestSuite) SetupTest() {
 	rebuildCompareCommand()
-	tempDir, err := os.MkdirTemp("", "compare-tests")
-	s.Require().NoError(err)
-	s.tempDir = tempDir
-
-	s.dataDir = path.Join(s.tempDir, "regex-assembly")
-	err = os.MkdirAll(s.dataDir, fs.ModePerm)
+	s.dataDir = path.Join(s.T().TempDir(), "regex-assembly")
+	err := os.MkdirAll(s.dataDir, fs.ModePerm)
 	s.Require().NoError(err)
 
-	s.rulesDir = path.Join(s.tempDir, "rules")
+	s.rulesDir = path.Join(s.T().TempDir(), "rules")
 	err = os.Mkdir(s.rulesDir, fs.ModePerm)
-	s.Require().NoError(err)
-}
-
-func (s *compareTestSuite) TearDownTest() {
-	err := os.RemoveAll(s.tempDir)
 	s.Require().NoError(err)
 }
 
@@ -72,7 +62,7 @@ func TestRunCompareTestSuite(t *testing.T) {
 func (s *compareTestSuite) TestCompare_NormalRuleId() {
 	s.writeDataFile("123456.ra", "")
 	s.writeRuleFile("123456", `SecRule... "@rx regex" \\`+"\nid:123456")
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "compare", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "compare", "123456"})
 	cmd, _ := rootCmd.ExecuteC()
 
 	s.Equal("compare", cmd.Name())
@@ -95,7 +85,7 @@ SecRule... "@rx oldbar" \
 id:123457`)
 	s.writeDataFile("123456.ra", "foo")
 	s.writeDataFile("123457.ra", "bar")
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "compare", "--all"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "compare", "--all"})
 	cmd, _ := rootCmd.ExecuteC()
 
 	s.Equal("compare", cmd.Name())
@@ -127,7 +117,7 @@ func (s *compareTestSuite) TestCompare_NoChange() {
 	s.writeRuleFile("123456", `SecRule... "@rx foo" \
 id:123456`)
 	s.writeDataFile("123456.ra", "foo")
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "compare", "--all"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "compare", "--all"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -146,7 +136,7 @@ func (s *compareTestSuite) TestCompare_Change() {
 	s.writeRuleFile("123456", `SecRule... "@rx oldfoo" \
 id:123456`)
 	s.writeDataFile("123456.ra", "foo")
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "compare", "--all"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "compare", "--all"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 

--- a/cmd/regex_format_test.go
+++ b/cmd/regex_format_test.go
@@ -17,7 +17,6 @@ import (
 
 type formatTestSuite struct {
 	suite.Suite
-	tempDir    string
 	dataDir    string
 	includeDir string
 }
@@ -25,21 +24,12 @@ type formatTestSuite struct {
 func (s *formatTestSuite) SetupTest() {
 	rebuildFormatCommand()
 
-	tempDir, err := os.MkdirTemp("", "format-tests")
-	s.Require().NoError(err)
-	s.tempDir = tempDir
-
-	s.dataDir = path.Join(s.tempDir, "regex-assembly")
-	err = os.MkdirAll(s.dataDir, fs.ModePerm)
+	s.dataDir = path.Join(s.T().TempDir(), "regex-assembly")
+	err := os.MkdirAll(s.dataDir, fs.ModePerm)
 	s.Require().NoError(err)
 
 	s.includeDir = path.Join(s.dataDir, "include")
 	err = os.MkdirAll(s.includeDir, fs.ModePerm)
-	s.Require().NoError(err)
-}
-
-func (s *formatTestSuite) TearDownTest() {
-	err := os.RemoveAll(s.tempDir)
 	s.Require().NoError(err)
 }
 
@@ -49,7 +39,7 @@ func TestRunFormatTestSuite(t *testing.T) {
 
 func (s *formatTestSuite) TestFormat_NormalRuleId() {
 	s.writeDataFile("123456.ra", "")
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "123456"})
 	cmd, _ := rootCmd.ExecuteC()
 
 	s.Equal("format", cmd.Name())
@@ -61,7 +51,7 @@ func (s *formatTestSuite) TestFormat_NormalRuleId() {
 
 func (s *formatTestSuite) TestFormat_NormalIncludeName() {
 	s.writeIncludeFile("shell-data.ra", "")
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "shell-data"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "shell-data"})
 	cmd, _ := rootCmd.ExecuteC()
 
 	s.Equal("format", cmd.Name())
@@ -86,7 +76,7 @@ func (s *formatTestSuite) TestFormat_ArgumentAndAllFlag() {
 }
 
 func (s *formatTestSuite) TestFormat_Dash() {
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "-"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "-"})
 	_, err := rootCmd.ExecuteC()
 
 	s.EqualError(err, "invalid argument '-'")
@@ -96,7 +86,7 @@ func (s *formatTestSuite) TestFormat_Dash() {
 func (s *formatTestSuite) TestFormat_TrimsTabs() {
 	s.writeDataFile("123456.ra", `line1	
 	line2`)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -111,7 +101,7 @@ line2
 func (s *formatTestSuite) TestFormat_TrimsSpaces() {
 	s.writeDataFile("123456.ra", `line1    
     line2`)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -127,7 +117,7 @@ func (s *formatTestSuite) TestFormat_IndentsAssembleBlock() {
 	s.writeDataFile("123456.ra", `##!> assemble
     		line
 ##!<`)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -156,7 +146,7 @@ func (s *formatTestSuite) TestFormat_IndentsNestedAssembleBlocks() {
 		  ##!=>	
 		  			##!<
 ##!<`)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -185,7 +175,7 @@ func (s *formatTestSuite) TestFormat_EndOfFileHasNewLineAfterNoNewLine() {
 	s.writeDataFile("123456.ra", `##!> assemble
     		line
 ##!<`)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -203,7 +193,7 @@ func (s *formatTestSuite) TestFormat_EndOfFileHasNewLineAfterOneNewLine() {
     		line
 ##!<
 `)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -222,7 +212,7 @@ func (s *formatTestSuite) TestFormat_EndOfFileHasNewLineAfterTwoNewLines() {
 ##!<
 
 `)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -237,7 +227,7 @@ func (s *formatTestSuite) TestFormat_EndOfFileHasNewLineAfterTwoNewLines() {
 
 func (s *formatTestSuite) TestFormat_EndOfFileHasNewLineIfEmpty() {
 	s.writeDataFile("123456.ra", "")
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -254,7 +244,7 @@ func (s *formatTestSuite) TestFormat_DoesNotRemoveEmptyLines() {
   line
 	   
 ##!<`)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -278,7 +268,7 @@ func (s *formatTestSuite) TestFormat_DoesNotRemoveComments() {
   line
 ##! a comment	
 ##!<`)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -305,7 +295,7 @@ func (s *formatTestSuite) TestFormat_OnlyIndentsAssembleProcessor() {
 ##!<
 
 ##!<`)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -332,7 +322,7 @@ func (s *formatTestSuite) TestFormat_FormatsProcessors() {
 ##!> define 	homer   	simpson 
 ##!<
 ##!<`)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -353,7 +343,7 @@ func (s *formatTestSuite) TestFormat_FormatsFlags() {
   ##!+ i
 ##!+ i 	
 `)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -371,7 +361,7 @@ func (s *formatTestSuite) TestFormat_FormatsPrefix() {
   ##!^ prefix with leading white space
 ##!^ prefix with trailing white space 	
 `)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -389,7 +379,7 @@ func (s *formatTestSuite) TestFormat_FormatsSuffix() {
   ##!$ suffix with leading white space
 ##!$ suffix with trailing white space 	
 `)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -407,7 +397,7 @@ func (s *formatTestSuite) TestFormat_FormatsDefinitions() {
   ##!> define with-leading-white-space homer
 ##!> define with-trailing-white-space homer 	
 `)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -425,7 +415,7 @@ func (s *formatTestSuite) TestFormat_FormatsIncludes() {
   ##!> include with-leading-white-space
 ##!> include with-trailing-white-space 	
 `)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -443,7 +433,7 @@ func (s *formatTestSuite) TestFormat_FormatsIncludes_WithSuffixReplacements() {
 ##!> include homer -- r s f g
 ##!> include marge
 `)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -461,7 +451,7 @@ func (s *formatTestSuite) TestFormat_FormatsExcept() {
   ##!> include-except with-leading-white-space homer
 ##!> include-except with-trailing-white-space homer	 
 `)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -479,7 +469,7 @@ func (s *formatTestSuite) TestFormat_FormatsExcept_WithSuffixReplacements() {
 ##!> include-except includefile exclude1 exclude2 -- @ [\s<>] ~ \S
 ##!> include-except simpson homer
 `)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -504,7 +494,7 @@ this is a regex
 ^[a-z]this is another regex
 {1,3}[Bb]lah
 `)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "-c", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "-c", "123456"})
 
 	_, err := rootCmd.ExecuteC()
 	s.EqualError(err, fmt.Sprintf("File not properly formatted: %s", path.Join(s.dataDir, "123456.ra")))
@@ -522,7 +512,7 @@ func (s *formatTestSuite) TestIgnoreCaseFlagWithUppercase_FirstCharacter() {
 ##!+ i
 [First] letter is uppercase
 `)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "-c", "123456", "-o", "github"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "-c", "123456", "-o", "github"})
 
 	_, err := rootCmd.ExecuteC()
 	s.EqualError(err, fmt.Sprintf("File not properly formatted: %s", path.Join(s.dataDir, "123456.ra")))
@@ -540,7 +530,7 @@ func (s *formatTestSuite) TestIgnoreCaseFlagWithUppercase_LastCharacter() {
 ##!+ i
 Last letter is upper[casE]
 `)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "-c", "123456", "-o", "github"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "-c", "123456", "-o", "github"})
 
 	_, err := rootCmd.ExecuteC()
 	s.EqualError(err, fmt.Sprintf("File not properly formatted: %s", path.Join(s.dataDir, "123456.ra")))
@@ -559,7 +549,7 @@ func (s *formatTestSuite) TestIgnoreCaseFlagWithUppercase_PlusDefinitions() {
 ##!+ i
 multiple escape sequences \A\B\S should be good.
 `)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "-c", "123456", "-o", "github"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "-c", "123456", "-o", "github"})
 
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
@@ -576,7 +566,7 @@ func (s *formatTestSuite) TestIgnoreCaseFlagWithUppercase_PlusDefinitionsWithUpp
 ##!+ i
 multiple escape sequences \A\B\S should be good.
 `)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "-c", "123456", "-o", "github"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "-c", "123456", "-o", "github"})
 
 	_, err := rootCmd.ExecuteC()
 	s.EqualError(err, fmt.Sprintf("File not properly formatted: %s", path.Join(s.dataDir, "123456.ra")))
@@ -594,7 +584,7 @@ func (s *formatTestSuite) TestIgnoreCaseFlagWithUppercase_ComplexCharacterClass(
 ##!+ i
 I'm complex: [^S$%_+-fG-].
 `)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "-c", "123456", "-o", "github"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "-c", "123456", "-o", "github"})
 
 	_, err := rootCmd.ExecuteC()
 	s.EqualError(err, fmt.Sprintf("File not properly formatted: %s", path.Join(s.dataDir, "123456.ra")))
@@ -612,7 +602,7 @@ func (s *formatTestSuite) TestIgnoreCaseFlagWithUppercase_CharacterClassWithBrac
 ##!+ i
 Chara[ct]er class with brackets: [$l\][2R [fl\]iF]
 `)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "-c", "123456", "-o", "github"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "-c", "123456", "-o", "github"})
 
 	_, err := rootCmd.ExecuteC()
 	s.EqualError(err, fmt.Sprintf("File not properly formatted: %s", path.Join(s.dataDir, "123456.ra")))
@@ -630,7 +620,7 @@ func (s *formatTestSuite) TestIgnoreCaseFlagWithUppercase_IgnoreShortHands() {
 ##!+ i
 [\W\S]
 `)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "format", "-c", "123456", "-o", "github"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "format", "-c", "123456", "-o", "github"})
 
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)

--- a/cmd/regex_generate_test.go
+++ b/cmd/regex_generate_test.go
@@ -14,24 +14,14 @@ import (
 
 type generateTestSuite struct {
 	suite.Suite
-	tempDir string
 	dataDir string
 }
 
 func (s *generateTestSuite) SetupTest() {
 	rebuildGenerateCommand()
 
-	tempDir, err := os.MkdirTemp("", "generate-tests")
-	s.Require().NoError(err)
-	s.tempDir = tempDir
-
-	s.dataDir = path.Join(s.tempDir, "regex-assembly")
-	err = os.MkdirAll(s.dataDir, fs.ModePerm)
-	s.Require().NoError(err)
-}
-
-func (s *generateTestSuite) TearDownTest() {
-	err := os.RemoveAll(s.tempDir)
+	s.dataDir = path.Join(s.T().TempDir(), "regex-assembly")
+	err := os.MkdirAll(s.dataDir, fs.ModePerm)
 	s.Require().NoError(err)
 }
 
@@ -41,7 +31,7 @@ func TestRunGenerateTestSuite(t *testing.T) {
 
 func (s *generateTestSuite) TestGenerate_NormalRuleId() {
 	s.writeDatafile("123456.ra", "")
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "generate", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "generate", "123456"})
 	cmd, _ := rootCmd.ExecuteC()
 
 	s.Equal("generate", cmd.Name())
@@ -59,7 +49,7 @@ func (s *generateTestSuite) TestGenerate_NoRuleId() {
 }
 
 func (s *generateTestSuite) TestGenerate_Dash() {
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "generate", "-"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "generate", "-"})
 	_, err := rootCmd.ExecuteC()
 
 	s.Require().NoError(err)

--- a/cmd/regex_test.go
+++ b/cmd/regex_test.go
@@ -14,7 +14,6 @@ import (
 
 type regexTestSuite struct {
 	suite.Suite
-	tempDir  string
 	dataDir  string
 	rulesDir string
 }
@@ -23,21 +22,12 @@ func (s *regexTestSuite) SetupTest() {
 	rebuildRegexCommand()
 	rebuildCompareCommand()
 
-	tempDir, err := os.MkdirTemp("", "regex-tests")
-	s.Require().NoError(err)
-	s.tempDir = tempDir
-
-	s.dataDir = path.Join(s.tempDir, "regex-assembly")
-	err = os.MkdirAll(s.dataDir, fs.ModePerm)
+	s.dataDir = path.Join(s.T().TempDir(), "regex-assembly")
+	err := os.MkdirAll(s.dataDir, fs.ModePerm)
 	s.Require().NoError(err)
 
-	s.rulesDir = path.Join(s.tempDir, "rules")
+	s.rulesDir = path.Join(s.T().TempDir(), "rules")
 	err = os.Mkdir(s.rulesDir, fs.ModePerm)
-	s.Require().NoError(err)
-}
-
-func (s *regexTestSuite) TearDownTest() {
-	err := os.RemoveAll(s.tempDir)
 	s.Require().NoError(err)
 }
 
@@ -47,7 +37,7 @@ func TestRunRegexTestSuite(t *testing.T) {
 
 func (s *regexTestSuite) TestRegex_ParseRuleId() {
 	s.writeDataFile("123456.ra", "")
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "generate", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "generate", "123456"})
 	_, err := rootCmd.ExecuteC()
 
 	s.Require().NoError(err, "failed to execute rootCmd")
@@ -59,7 +49,7 @@ func (s *regexTestSuite) TestRegex_ParseRuleId() {
 
 func (s *regexTestSuite) TestRegex_ParseRuleIdAndChainOffset() {
 	s.writeDataFile("123456-chain19.ra", "")
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "generate", "123456-chain19"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "generate", "123456-chain19"})
 	_, err := rootCmd.ExecuteC()
 
 	s.Require().NoError(err, "failed to execute rootCmd")
@@ -71,7 +61,7 @@ func (s *regexTestSuite) TestRegex_ParseRuleIdAndChainOffset() {
 
 func (s *regexTestSuite) TestRegex_ParseRuleIdAndChainOffsetAndFileName() {
 	s.writeDataFile("123456-chain255.ra", "")
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "generate", "123456-chain255.ra"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "generate", "123456-chain255.ra"})
 	_, err := rootCmd.ExecuteC()
 
 	s.Require().NoError(err, "failed to execute rootCmd")
@@ -83,7 +73,7 @@ func (s *regexTestSuite) TestRegex_ParseRuleIdAndChainOffsetAndFileName() {
 
 func (s *regexTestSuite) TestRegex_ParseRuleIdAndFileName() {
 	s.writeDataFile("123456.ra", "")
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "regex", "generate", "123456.ra"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "regex", "generate", "123456.ra"})
 	_, err := rootCmd.ExecuteC()
 
 	s.Require().NoError(err, "failed to execute rootCmd")

--- a/cmd/self_update_test.go
+++ b/cmd/self_update_test.go
@@ -19,23 +19,15 @@ import (
 
 type selfUpdateTestSuite struct {
 	suite.Suite
-	tempDir        string
 	executablePath string
 }
 
 func (s *selfUpdateTestSuite) SetupTest() {
 	var err error
 	rebuildSelfUpdateCommand()
-	s.tempDir, err = os.MkdirTemp("", "self-update-tests")
-	s.Require().NoError(err)
 
-	s.executablePath = path.Join(s.tempDir, "crs-toolchain")
+	s.executablePath = path.Join(s.T().TempDir(), "crs-toolchain")
 	err = os.WriteFile(s.executablePath, []byte("Fake Binary"), fs.ModePerm)
-	s.Require().NoError(err)
-}
-
-func (s *selfUpdateTestSuite) TearDownTest() {
-	err := os.RemoveAll(s.tempDir)
 	s.Require().NoError(err)
 }
 

--- a/cmd/util_fp_finder.go
+++ b/cmd/util_fp_finder.go
@@ -28,7 +28,7 @@ func createFpFinderCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "fp-finder FILEPATH",
 		Short: `False positive finder`,
-		Args: cobra.MatchAll(cobra.MaximumNArgs(1), func(cmd *cobra.Command, args []string) error {
+		Args: cobra.MatchAll(cobra.MaximumNArgs(1), cobra.MinimumNArgs(1), func(cmd *cobra.Command, args []string) error {
 			return nil
 		}),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -63,6 +63,15 @@ func buildFpFinderCommand() {
 	utilCmd.AddCommand(fpFinderCommand)
 	fpFinderCommand.Flags().StringVarP(&extendedDictPath, "extended-dictionary", "e", "", "Absolute or relative path to the extended dictionary")
 	fpFinderCommand.Flags().StringVarP(&englishDictionaryCommitRef, "english-dictionary-commit-ref", "c", "", "English dictionary commit ref from GitHub https://github.com/dwyl/english-words/blob/master/words_alpha.txt")
+}
+
+func rebuildFpFinderCommand() {
+	if fpFinderCommand != nil {
+		fpFinderCommand.Parent().RemoveCommand(fpFinderCommand)
+	}
+
+	fpFinderCommand = createFpFinderCommand()
+	buildFpFinderCommand()
 }
 
 func checkFilePath(path string) bool {

--- a/cmd/util_fp_finder_test.go
+++ b/cmd/util_fp_finder_test.go
@@ -1,0 +1,34 @@
+// Copyright 2022 OWASP Core Rule Set Project
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type fpFinderTest struct {
+	suite.Suite
+}
+
+func (s *fpFinderTest) SetupTest() {
+	rebuildFpFinderCommand()
+}
+
+func TestRunFpFinderTest(t *testing.T) {
+	suite.Run(t, new(fpFinderTest))
+}
+
+func (s *fpFinderTest) TestNoArgument() {
+	rootCmd.SetArgs([]string{"util", "fp-finder"})
+	cmd, err := rootCmd.ExecuteC()
+	s.Equal(err.Error(), "requires at least 1 arg(s), only received 0")
+
+	s.Equal("fp-finder", cmd.Name())
+
+	flags := cmd.Flags()
+	args := flags.Args()
+	s.Len(args, 0)
+}

--- a/cmd/util_renumber_tests_test.go
+++ b/cmd/util_renumber_tests_test.go
@@ -16,7 +16,6 @@ import (
 
 type renumberTestsTestSuite struct {
 	suite.Suite
-	tempDir  string
 	testsDir string
 }
 
@@ -54,21 +53,12 @@ func (s *renumberTestsTestSuite) SetupTest() {
 	rebuildUtilCommand()
 	rebuildRenumberTestsCommand()
 
-	tempDir, err := os.MkdirTemp("", "renumber-tests-tests")
-	s.Require().NoError(err)
-	s.tempDir = tempDir
-
-	dataDir := path.Join(s.tempDir, "regex-assembly")
-	err = os.MkdirAll(dataDir, fs.ModePerm)
+	dataDir := path.Join(s.T().TempDir(), "regex-assembly")
+	err := os.MkdirAll(dataDir, fs.ModePerm)
 	s.Require().NoError(err)
 
-	s.testsDir = path.Join(s.tempDir, "tests", "regression", "tests")
+	s.testsDir = path.Join(s.T().TempDir(), "tests", "regression", "tests")
 	err = os.MkdirAll(s.testsDir, fs.ModePerm)
-	s.Require().NoError(err)
-}
-
-func (s *renumberTestsTestSuite) TearDownTest() {
-	err := os.RemoveAll(s.tempDir)
 	s.Require().NoError(err)
 }
 
@@ -78,7 +68,7 @@ func TestRunRenumberTestsTestSuite(t *testing.T) {
 
 func (s *renumberTestsTestSuite) TestRenumberTests_WithYaml() {
 	s.writeTestFile("123456.yaml", "test_id: homer")
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "util", "renumber-tests", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "util", "renumber-tests", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -88,7 +78,7 @@ func (s *renumberTestsTestSuite) TestRenumberTests_WithYaml() {
 
 func (s *renumberTestsTestSuite) TestRenumberTests_WithYml() {
 	s.writeTestFile("123456.yml", "test_id: homer")
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "util", "renumber-tests", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "util", "renumber-tests", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -98,7 +88,7 @@ func (s *renumberTestsTestSuite) TestRenumberTests_WithYml() {
 
 func (s *renumberTestsTestSuite) TestRenumberTests_NormalRuleId() {
 	s.writeTestFile("123456.yaml", "")
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "util", "renumber-tests", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "util", "renumber-tests", "123456"})
 	cmd, _ := rootCmd.ExecuteC()
 
 	s.Equal("renumber-tests", cmd.Name())
@@ -123,7 +113,7 @@ func (s *renumberTestsTestSuite) TestRenumberTests_ArgumentAndAllFlag() {
 }
 
 func (s *renumberTestsTestSuite) TestRenumberTests_Dash() {
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "util", "renumber-tests", "-"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "util", "renumber-tests", "-"})
 	_, err := rootCmd.ExecuteC()
 
 	s.EqualError(err, "invalid argument '-'")
@@ -132,7 +122,7 @@ func (s *renumberTestsTestSuite) TestRenumberTests_Dash() {
 func (s *renumberTestsTestSuite) TestRenumberTests_CheckOnly() {
 	contents := "test_id: homer"
 	s.writeTestFile("123456.yaml", contents)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "util", "renumber-tests", "-c", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "util", "renumber-tests", "-c", "123456"})
 	_, err := rootCmd.ExecuteC()
 
 	s.EqualError(err, "Tests are not properly numbered")
@@ -146,7 +136,7 @@ func (s *renumberTestsTestSuite) TestRenumberTests_GitHubOutput() {
 
 	contents := "test_id: homer"
 	s.writeTestFile("123456.yaml", contents)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "util", "renumber-tests", "-cao", "github"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "util", "renumber-tests", "-cao", "github"})
 	_, err := rootCmd.ExecuteC()
 
 	s.ErrorIs(err, &util.TestNumberingError{})
@@ -163,7 +153,7 @@ func (s *renumberTestsTestSuite) TestRenumberTests_GitHubOutput() {
 
 func (s *renumberTestsTestSuite) TestRenumberTests_Legacy_WithYaml() {
 	s.writeTestFile("123456.yaml", "test_title: homer")
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "util", "renumber-tests", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "util", "renumber-tests", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -173,7 +163,7 @@ func (s *renumberTestsTestSuite) TestRenumberTests_Legacy_WithYaml() {
 
 func (s *renumberTestsTestSuite) TestRenumberTests_Legacy_WithYml() {
 	s.writeTestFile("123456.yml", "test_title: homer")
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "util", "renumber-tests", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "util", "renumber-tests", "123456"})
 	_, err := rootCmd.ExecuteC()
 	s.Require().NoError(err)
 
@@ -184,7 +174,7 @@ func (s *renumberTestsTestSuite) TestRenumberTests_Legacy_WithYml() {
 func (s *renumberTestsTestSuite) TestRenumberTests_Legacy_CheckOnly() {
 	contents := "test_title: homer"
 	s.writeTestFile("123456.yaml", contents)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "util", "renumber-tests", "-c", "123456"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "util", "renumber-tests", "-c", "123456"})
 	_, err := rootCmd.ExecuteC()
 
 	s.EqualError(err, "Tests are not properly numbered")
@@ -198,7 +188,7 @@ func (s *renumberTestsTestSuite) TestRenumberTests_Legacy_GitHubOutput() {
 
 	contents := "test_title: homer"
 	s.writeTestFile("123456.yaml", contents)
-	rootCmd.SetArgs([]string{"-d", s.tempDir, "util", "renumber-tests", "-cao", "github"})
+	rootCmd.SetArgs([]string{"-d", s.T().TempDir(), "util", "renumber-tests", "-cao", "github"})
 	_, err := rootCmd.ExecuteC()
 
 	s.ErrorIs(err, &util.TestNumberingError{})

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -16,7 +16,6 @@ import (
 
 type configurationTestSuite struct {
 	suite.Suite
-	tempDir     string
 	assemblyDir string
 }
 
@@ -31,17 +30,8 @@ func (s *configurationTestSuite) writeConfig(config *Configuration) {
 }
 
 func (s *configurationTestSuite) SetupTest() {
-	tempDir, err := os.MkdirTemp("", "configuration-tests")
-	s.Require().NoError(err)
-	s.tempDir = tempDir
-
-	s.assemblyDir = path.Join(s.tempDir, "regex-assembly")
-	err = os.MkdirAll(s.assemblyDir, fs.ModePerm)
-	s.Require().NoError(err)
-}
-
-func (s *configurationTestSuite) TearDownTest() {
-	err := os.RemoveAll(s.tempDir)
+	s.assemblyDir = path.Join(s.T().TempDir(), "regex-assembly")
+	err := os.MkdirAll(s.assemblyDir, fs.ModePerm)
 	s.Require().NoError(err)
 }
 

--- a/regex/operators/assembler_test.go
+++ b/regex/operators/assembler_test.go
@@ -4,7 +4,6 @@
 package operators
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -16,8 +15,7 @@ import (
 
 type assemblerTestSuite struct {
 	suite.Suite
-	ctx     *processors.Context
-	tempDir string
+	ctx *processors.Context
 }
 
 type fileFormatTestSuite assemblerTestSuite
@@ -36,82 +34,33 @@ func TestRunAssemblerTestSuite(t *testing.T) {
 }
 
 func (s *assemblerTestSuite) SetupSuite() {
-	var err error
-	s.tempDir, err = os.MkdirTemp("", "assemble-test")
-	s.Require().NoError(err)
-	rootContext := context.New(s.tempDir, "toolchain.yaml")
+	rootContext := context.New(s.T().TempDir(), "toolchain.yaml")
 	s.ctx = processors.NewContext(rootContext)
-}
-
-func (s *assemblerTestSuite) TearDownSuite() {
-	err := os.RemoveAll(s.tempDir)
-	s.Require().NoError(err)
 }
 
 func (s *fileFormatTestSuite) SetupSuite() {
-	var err error
-	s.tempDir, err = os.MkdirTemp("", "file-format-test")
-	s.Require().NoError(err)
-	rootContext := context.New(s.tempDir, "toolchain.yaml")
+	rootContext := context.New(s.T().TempDir(), "toolchain.yaml")
 	s.ctx = processors.NewContext(rootContext)
-}
-
-func (s *fileFormatTestSuite) TearDownSuite() {
-	err := os.RemoveAll(s.tempDir)
-	s.Require().NoError(err)
 }
 
 func (s *specialCommentsTestSuite) SetupSuite() {
-	var err error
-	s.tempDir, err = os.MkdirTemp("", "special-comments-test")
-	s.Require().NoError(err)
-	rootContext := context.New(s.tempDir, "toolchain.yaml")
+	rootContext := context.New(s.T().TempDir(), "toolchain.yaml")
 	s.ctx = processors.NewContext(rootContext)
-}
-
-func (s *specialCommentsTestSuite) TearDownSuite() {
-	err := os.RemoveAll(s.tempDir)
-	s.Require().NoError(err)
 }
 
 func (s *specialCasesTestSuite) SetupSuite() {
-	var err error
-	s.tempDir, err = os.MkdirTemp("", "special-cases-test")
-	s.Require().NoError(err)
-	rootContext := context.New(s.tempDir, "toolchain.yaml")
+	rootContext := context.New(s.T().TempDir(), "toolchain.yaml")
 	s.ctx = processors.NewContext(rootContext)
-}
-
-func (s *specialCasesTestSuite) TearDownSuite() {
-	err := os.RemoveAll(s.tempDir)
-	s.Require().NoError(err)
 }
 
 func (s *definitionsTestSuite) SetupSuite() {
-	var err error
-	s.tempDir, err = os.MkdirTemp("", "definitions-test")
-	s.Require().NoError(err)
-	rootContext := context.New(s.tempDir, "toolchain.yaml")
+	rootContext := context.New(s.T().TempDir(), "toolchain.yaml")
 	s.ctx = processors.NewContext(rootContext)
-}
-
-func (s *definitionsTestSuite) TearDownSuite() {
-	err := os.RemoveAll(s.tempDir)
-	s.Require().NoError(err)
 }
 
 func (s *preprocessorsTestSuite) SetupSuite() {
-	var err error
-	s.tempDir, err = os.MkdirTemp("", "preprocessor-test")
-	s.Require().NoError(err)
-
-	rootContext := context.NewWithConfiguration(s.tempDir, s.newTestConfiguration())
+	rootContext := context.NewWithConfiguration(s.T().TempDir(), s.newTestConfiguration())
 	s.ctx = processors.NewContext(rootContext)
-}
-
-func (s *preprocessorsTestSuite) TearDownSuite() {
-	err := os.RemoveAll(s.tempDir)
-	s.Require().NoError(err)
 }
 
 func (s *preprocessorsTestSuite) newTestConfiguration() *configuration.Configuration {

--- a/regex/parser/definition_test.go
+++ b/regex/parser/definition_test.go
@@ -10,6 +10,7 @@ import (
 	"io/fs"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -30,7 +31,7 @@ func TestParserDefinitionsTestSuite(t *testing.T) {
 }
 
 func (s *parserDefinitionTestSuite) SetupSuite() {
-	rootContext := context.New(os.TempDir(), "toolchain.yaml")
+	rootContext := context.New(filepath.Dir(s.T().TempDir()), "toolchain.yaml")
 	s.ctx = processors.NewContext(rootContext)
 	s.reader = strings.NewReader("##!> define this-is-a-text [a-zA-J]+8\n" +
 		"##!> define this-is-another-text [0-9](pine|apple)\n" +
@@ -50,18 +51,14 @@ func (s *parserDefinitionTestSuite) TestParserDefinition_BasicTest() {
 }
 
 func (s *parserIncludeWithDefinitions) SetupSuite() {
-	tempDir, err := os.MkdirTemp("", "include-multi-tests")
-	s.Require().NoError(err)
-	s.tempDir = tempDir
-
-	s.includeDir = path.Join(s.tempDir, "regex-assembly", "include")
-	err = os.MkdirAll(s.includeDir, fs.ModePerm)
+	s.includeDir = path.Join(s.T().TempDir(), "regex-assembly", "include")
+	err := os.MkdirAll(s.includeDir, fs.ModePerm)
 	s.Require().NoError(err)
 
-	rootContext := context.New(os.TempDir(), "toolchain.yaml")
+	rootContext := context.New(filepath.Dir(s.T().TempDir()), "toolchain.yaml")
 	s.ctx = processors.NewContext(rootContext)
 	for i := 0; i < 4; i++ {
-		file, err := os.Create(path.Join(s.tempDir, fmt.Sprintf("multi-definitions-%d.ra", i)))
+		file, err := os.Create(path.Join(s.T().TempDir(), fmt.Sprintf("multi-definitions-%d.ra", i)))
 		s.Require().NoError(err, "couldn't create %s file", file.Name())
 		if i == 0 {
 			// Only the initial include goes to the reader

--- a/regex/parser/include_except_test.go
+++ b/regex/parser/include_except_test.go
@@ -21,7 +21,6 @@ import (
 type parserIncludeExceptTestSuite struct {
 	suite.Suite
 	ctx         *processors.Context
-	tempDir     string
 	assemblyDir string
 	includeDir  string
 	excludeDir  string
@@ -43,12 +42,8 @@ func TestParserRunIncludeExceptTestSuite(t *testing.T) {
 }
 
 func (s *parserIncludeExceptTestSuite) SetupTest() {
-	var err error
-	s.tempDir, err = os.MkdirTemp("", "include-except-tests")
-	s.Require().NoError(err)
-
-	s.assemblyDir = path.Join(s.tempDir, "regex-assembly")
-	err = os.MkdirAll(s.assemblyDir, fs.ModePerm)
+	s.assemblyDir = path.Join(s.T().TempDir(), "regex-assembly")
+	err := os.MkdirAll(s.assemblyDir, fs.ModePerm)
 	s.Require().NoError(err)
 
 	s.includeDir = path.Join(s.assemblyDir, "include")
@@ -59,12 +54,8 @@ func (s *parserIncludeExceptTestSuite) SetupTest() {
 	err = os.MkdirAll(s.excludeDir, fs.ModePerm)
 	s.Require().NoError(err)
 
-	rootContext := context.New(s.tempDir, "toolchain.yaml")
+	rootContext := context.New(s.T().TempDir(), "toolchain.yaml")
 	s.ctx = processors.NewContext(rootContext)
-}
-
-func (s *parserIncludeExceptTestSuite) TearDownTest() {
-	s.Require().NoError(os.RemoveAll(s.tempDir))
 }
 
 func (s *parserIncludeExceptTestSuite) TestIncludeExcept_MoreExcludesThanIncludes() {

--- a/regex/parser/include_multiple_test.go
+++ b/regex/parser/include_multiple_test.go
@@ -23,7 +23,6 @@ type parserMultiIncludeTestSuite struct {
 	suite.Suite
 	ctx         *processors.Context
 	reader      io.Reader
-	tempDir     string
 	includeDir  string
 	includeFile []*os.File
 }
@@ -34,15 +33,11 @@ func TestRunParserMultiIncludeTestSuite(t *testing.T) {
 
 // Test Suite to perform multiple inclusions
 func (s *parserMultiIncludeTestSuite) SetupSuite() {
-	tempDir, err := os.MkdirTemp("", "include-multi-tests")
-	s.Require().NoError(err)
-	s.tempDir = tempDir
-
-	s.includeDir = path.Join(s.tempDir, "regex-assembly", "include")
-	err = os.MkdirAll(s.includeDir, fs.ModePerm)
+	s.includeDir = path.Join(s.T().TempDir(), "regex-assembly", "include")
+	err := os.MkdirAll(s.includeDir, fs.ModePerm)
 	s.Require().NoError(err)
 
-	rootContext := context.New(s.tempDir, "toolchain.yaml")
+	rootContext := context.New(s.T().TempDir(), "toolchain.yaml")
 	s.ctx = processors.NewContext(rootContext)
 	for i := 0; i < 4; i++ {
 		file, err := os.Create(path.Join(s.includeDir, fmt.Sprintf("multi-include-%d.ra", i)))
@@ -58,11 +53,6 @@ func (s *parserMultiIncludeTestSuite) SetupSuite() {
 			s.Require().NoError(err, "writing temp include file failed")
 		}
 	}
-}
-
-func (s *parserMultiIncludeTestSuite) TearDownSuite() {
-	err := os.RemoveAll(s.tempDir)
-	s.Require().NoError(err)
 }
 
 func (s *parserMultiIncludeTestSuite) TestParserMultiInclude_FromMultiFile() {

--- a/regex/parser/include_test.go
+++ b/regex/parser/include_test.go
@@ -23,7 +23,6 @@ type parserIncludeTestSuite struct {
 	suite.Suite
 	ctx         *processors.Context
 	reader      io.Reader
-	tempDir     string
 	includeDir  string
 	includeFile *os.File
 }
@@ -40,15 +39,11 @@ func TestRunParserIncludeTestSuite(t *testing.T) {
 }
 
 func (s *parserIncludeTestSuite) SetupTest() {
-	var err error
-	s.tempDir, err = os.MkdirTemp("", "include-tests")
+	s.includeDir = path.Join(s.T().TempDir(), "regex-assembly", "include")
+	err := os.MkdirAll(s.includeDir, fs.ModePerm)
 	s.Require().NoError(err)
 
-	s.includeDir = path.Join(s.tempDir, "regex-assembly", "include")
-	err = os.MkdirAll(s.includeDir, fs.ModePerm)
-	s.Require().NoError(err)
-
-	rootContext := context.New(s.tempDir, "toolchain.yaml")
+	rootContext := context.New(s.T().TempDir(), "toolchain.yaml")
 	s.ctx = processors.NewContext(rootContext)
 	s.includeFile, err = os.Create(path.Join(s.includeDir, "test.ra"))
 	s.Require().NoError(err, "couldn't create %s file", s.includeFile.Name())
@@ -56,7 +51,6 @@ func (s *parserIncludeTestSuite) SetupTest() {
 
 func (s *parserIncludeTestSuite) TearDownTest() {
 	s.Require().NoError(s.includeFile.Close())
-	s.Require().NoError(os.RemoveAll(s.tempDir))
 }
 
 func (s *parserIncludeTestSuite) TestParserInclude_FromFile() {

--- a/regex/parser/include_with_definition_test.go
+++ b/regex/parser/include_with_definition_test.go
@@ -21,7 +21,6 @@ type parserIncludeWithDefinitions struct {
 	suite.Suite
 	ctx         *processors.Context
 	reader      io.Reader
-	tempDir     string
 	includeDir  string
 	includeFile []*os.File
 }

--- a/regex/processors/assemble_test.go
+++ b/regex/processors/assemble_test.go
@@ -4,7 +4,7 @@
 package processors
 
 import (
-	"os"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -14,36 +14,19 @@ import (
 
 type assembleTestSuite struct {
 	suite.Suite
-	ctx     *Context
-	tempDir string
+	ctx *Context
 }
 
 type fileFormatTestSuite assembleTestSuite
 
 func (suite *assembleTestSuite) SetupSuite() {
-	var err error
-	suite.tempDir, err = os.MkdirTemp("", "assemble-test")
-	suite.Require().NoError(err)
-	rootContext := context.New(suite.tempDir, "toolchain.yaml")
+	rootContext := context.New(suite.T().TempDir(), "toolchain.yaml")
 	suite.ctx = NewContext(rootContext)
-}
-
-func (suite *assembleTestSuite) TearDownSuite() {
-	err := os.RemoveAll(suite.tempDir)
-	suite.Require().NoError(err)
 }
 
 func (suite *fileFormatTestSuite) SetupSuite() {
-	var err error
-	suite.tempDir, err = os.MkdirTemp("", "file-format-test")
-	suite.Require().NoError(err)
-	rootContext := context.New(suite.tempDir, "toolchain.yaml")
+	rootContext := context.New(suite.T().TempDir(), "toolchain.yaml")
 	suite.ctx = NewContext(rootContext)
-}
-
-func (suite *fileFormatTestSuite) TearDownSuite() {
-	err := os.RemoveAll(suite.tempDir)
-	suite.Require().NoError(err)
 }
 
 func TestRunAssembleTestSuite(t *testing.T) {
@@ -55,8 +38,8 @@ func (s *assembleTestSuite) TestNewAssemble() {
 	assemble := NewAssemble(s.ctx)
 
 	s.NotNil(assemble)
-	s.Equal(assemble.proc.ctx.RootContext().RootDir(), s.tempDir)
-	s.Equal(assemble.proc.ctx.RootContext().AssemblyDir(), s.tempDir+"/regex-assembly")
+	s.Equal(assemble.proc.ctx.RootContext().RootDir(), s.T().TempDir())
+	s.Equal(assemble.proc.ctx.RootContext().AssemblyDir(), path.Join(s.T().TempDir(), "/regex-assembly"))
 }
 
 func (s *assembleTestSuite) TestAssemble_MultipleLines() {


### PR DESCRIPTION
Fixes #248 