### PR TITLE
fix: meta character escaping

### DIFF
--- a/regex/processors/cmdline.go
+++ b/regex/processors/cmdline.go
@@ -150,21 +150,28 @@ func (c *CmdLine) regexpStr(input string) string {
 	return result.String()
 }
 
-// regexpChar ensures that some special characters are escaped
+// regexpChar ensures that some special characters are escaped.
+// Note that we do this so we don't have to treat the entries in command
+// lists as regular expressions, i.e., entries like `c++` don't need to be
+// escaped.
 func (c *CmdLine) regexpChar(char byte) string {
 	logger.Trace().Msgf("regexpChar in: %v", char)
 
 	chars := ""
 	switch char {
 	case '.':
-		chars = "\\."
+		fallthrough
 	case '-':
-		chars = "\\-"
+		fallthrough
+	case '+':
+		chars = "\\" + string(char)
+	case ' ':
+		chars = "\\s+"
 	default:
 		chars = string(char)
 	}
 	logger.Trace().Msgf("regexpChar out: %s", chars)
-	return strings.ReplaceAll(chars, " ", "\\s+")
+	return chars
 }
 
 // Computes the evasion suffix based on the presence of `@` or `~` at

--- a/regex/processors/cmdline_test.go
+++ b/regex/processors/cmdline_test.go
@@ -98,13 +98,40 @@ func (s *cmdLineTestSuite) TestCmdLine_ProcessLineFoo() {
 	s.Equal(`f_av-u_o_av-u_o`, cmd.proc.lines[0])
 }
 
-func (s *cmdLineTestSuite) TestCmdLine_ProcessLinePattern() {
+func (s *cmdLineTestSuite) TestCmdLine_ProcessLineWithDash() {
 	cmd := NewCmdLine(s.ctx, CmdLineUnix)
 
-	err := cmd.ProcessLine(`gcc-10.`)
+	err := cmd.ProcessLine(`gcc-10`)
 	s.Require().NoError(err)
 
-	s.Equal(`g_av-u_c_av-u_c_av-u_\-_av-u_1_av-u_0_av-u_\.`, cmd.proc.lines[0])
+	s.Equal(`g_av-u_c_av-u_c_av-u_\-_av-u_1_av-u_0`, cmd.proc.lines[0])
+}
+
+func (s *cmdLineTestSuite) TestCmdLine_ProcessLineWithDot() {
+	cmd := NewCmdLine(s.ctx, CmdLineUnix)
+
+	err := cmd.ProcessLine(`gcc10.`)
+	s.Require().NoError(err)
+
+	s.Equal(`g_av-u_c_av-u_c_av-u_1_av-u_0_av-u_\.`, cmd.proc.lines[0])
+}
+
+func (s *cmdLineTestSuite) TestCmdLine_ProcessLineWithPlus() {
+	cmd := NewCmdLine(s.ctx, CmdLineUnix)
+
+	err := cmd.ProcessLine(`gcc10+`)
+	s.Require().NoError(err)
+
+	s.Equal(`g_av-u_c_av-u_c_av-u_1_av-u_0_av-u_\+`, cmd.proc.lines[0])
+}
+
+func (s *cmdLineTestSuite) TestCmdLine_ProcessLineWithSpace() {
+	cmd := NewCmdLine(s.ctx, CmdLineUnix)
+
+	err := cmd.ProcessLine(`gcc 10`)
+	s.Require().NoError(err)
+
+	s.Equal(`g_av-u_c_av-u_c_av-u_\s+_av-u_1_av-u_0`, cmd.proc.lines[0])
 }
 
 func (s *cmdLineTestSuite) TestCmdLine_ProcessLineFooWindows() {


### PR DESCRIPTION
The cmdline processor treats each line of input as a string, not a regular rexpression. However, the assembler treats input as regular expressions. The output of the cmdline processor must, therefore, be properly escaped.

The function responsible for handling escape sequences was missing the `+` character, causing literal `+` characters to end up being passed to the assembler.