### PR TITLE
feat: allow spaces in definitions

### DIFF
--- a/regex/definitions.go
+++ b/regex/definitions.go
@@ -16,7 +16,7 @@ var IncludeExceptRegex = regexp.MustCompile(`^##!>\s*include-except\s+(\S+)\s*(.
 // DefinitionRegex matches a definition processor line (##! define <name> <value>)
 // Everything up to the value of the definition is captured in group 1.
 // The name is captured in group 2, the value in group 3.
-var DefinitionRegex = regexp.MustCompile(`^(##!>\s*define\s+([a-zA-Z0-9-_]+)\s+)(\S+)\s*$`)
+var DefinitionRegex = regexp.MustCompile(`^(##!>\s*define\s+([a-zA-Z0-9-_]+)\s+)(\S(?:.*\S)?)\s*$`)
 
 // CommentRegex matches a comment line (##!, no other directives)
 var CommentRegex = regexp.MustCompile(`^\s*##!(?:[^^$+><=]|$)`)

--- a/regex/parser/definition_test.go
+++ b/regex/parser/definition_test.go
@@ -47,3 +47,25 @@ func (s *parserDefinitionTestSuite) TestParserDefinition_BasicTest() {
 	s.Equal(parser.variables["this-is-another-text"], "[0-9](pine|apple)", "failed to found definition variables in map")
 	s.Equal(expected.String(), actual.String())
 }
+
+func (s *parserDefinitionTestSuite) TestParserDefinition_ValueWithSpaces() {
+	reader := strings.NewReader("##!> define comparison-prefix [>< ]\n" +
+		"{{comparison-prefix}}something\n")
+	parser := NewParser(s.ctx, reader)
+	actual, _ := parser.Parse(false)
+	expected := bytes.NewBufferString("[>< ]something\n")
+
+	s.Equal("[>< ]", parser.variables["comparison-prefix"], "definition value with space in character class should be preserved")
+	s.Equal(expected.String(), actual.String())
+}
+
+func (s *parserDefinitionTestSuite) TestParserDefinition_ValueWithEscapedSpace() {
+	reader := strings.NewReader("##!> define space-pattern [><\\ ]\n" +
+		"{{space-pattern}}test\n")
+	parser := NewParser(s.ctx, reader)
+	actual, _ := parser.Parse(false)
+	expected := bytes.NewBufferString("[><\\ ]test\n")
+
+	s.Equal("[><\\ ]", parser.variables["space-pattern"], "definition value with escaped space should be preserved")
+	s.Equal(expected.String(), actual.String())
+}


### PR DESCRIPTION
<!-- Please sign your commits: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits -->
<!-- You don't need to remove these comments, they won't be added to the PR -->
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- allow spaces in definitions


## why

<!--
- Provide the justifications for the changes (e.g. business case).
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- write definitions that can have spaces

## references

<!--
- Link to any supporting GitHub issues or helpful documentation to add some context (e.g. StackOverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
