### PR TITLE
feat: add flag for printing the agenda, without creating a GH issue

### DIFF
--- a/chore/agenda/agenda.go
+++ b/chore/agenda/agenda.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -24,7 +25,7 @@ var logger = log.With().Str("component", "agenda").Logger()
 //go:embed agenda-next.md
 var agendaNextTemplate []byte
 
-func Agenda() {
+func Agenda(printOnly bool) {
 	opts := api.ClientOptions{
 		Headers: map[string]string{"Accept": "application/vnd.github+json"},
 		Timeout: 30 * time.Second,
@@ -50,7 +51,7 @@ func Agenda() {
 	logger.Info().Msg("Cloning wiki repository")
 	tempDir, err := os.MkdirTemp("", "crs-wiki")
 	if err != nil {
-		logger.Fatal().Err(err).Msg("failed to create temporary directory for cloning the wiki repository")
+		logger.Fatal().Err(err).Msg("Failed to create temporary directory for cloning the wiki repository")
 	}
 	defer func() {
 		err := os.RemoveAll(tempDir)
@@ -61,19 +62,27 @@ func Agenda() {
 	cloneWiki(tempDir, "wiki")
 	wikiDir := filepath.Join(tempDir, "wiki")
 
+	agendaBody := buildAgendaBody(client, wikiDir, previousDate, nextDate)
+	if printOnly {
+		if _, err := io.WriteString(os.Stdout, agendaBody); err != nil {
+			logger.Error().Err(err).Msg("Failed to print agenda body to terminal")
+		}
+		return
+	}
+
 	bodyJson, err := json.Marshal(&issueBody{
 		Title:  fmt.Sprintf("Monthly Chat Agenda %s %d (%s)", month, year, dateString),
 		Labels: []string{":bookmark: Meeting Agenda"},
-		Body:   buildAgendaBody(client, wikiDir, previousDate, nextDate),
+		Body:   agendaBody,
 	})
 	if err != nil {
-		logger.Fatal().Err(err).Msg("failed to serialize body of GH REST request")
+		logger.Fatal().Err(err).Msg("Failed to serialize body of GH REST request")
 	}
 
 	logger.Info().Msg("Creating new agenda issue")
 	response, err := client.Request(http.MethodPost, "repos/coreruleset/coreruleset/issues", bytes.NewReader(bodyJson))
 	if err != nil {
-		logger.Fatal().Err(err).Msg("creating agenda failed")
+		logger.Fatal().Err(err).Msg("Creating agenda failed")
 	}
 	defer response.Body.Close()
 
@@ -86,15 +95,15 @@ func Agenda() {
 
 func resetAgendaNext(wikiDir string) {
 	if err := os.WriteFile(filepath.Join(wikiDir, "Agenda-Next.md"), agendaNextTemplate, 0644); err != nil {
-		logger.Fatal().Msg(`failed to write "Agenda-Next.md"`)
+		logger.Fatal().Msg(`Failed to write "Agenda-Next.md"`)
 	}
 	out, err := utils.RunGit(wikiDir, "commit", "-m", "Reset Agenda-Next.md", "Agenda-Next.md")
 	if err != nil {
-		logger.Fatal().Err(err).Msgf(`failed to commit "Agenda-Next": %s`, out)
+		logger.Fatal().Err(err).Msgf(`Failed to commit "Agenda-Next": %s`, out)
 	}
 	out, err = utils.RunGit(wikiDir, "push")
 	if err != nil {
-		logger.Fatal().Err(err).Msgf(`failed to push "Agenda-Next": %s`, out)
+		logger.Fatal().Err(err).Msgf(`Failed to push "Agenda-Next": %s`, out)
 	}
 }
 
@@ -103,7 +112,7 @@ func buildAgendaBody(client *api.RESTClient, wikiDir string, previousDate time.T
 	agendaPath := filepath.Join(wikiDir, "Agenda-Next.md")
 	template, err := os.ReadFile(agendaPath)
 	if err != nil {
-		logger.Fatal().Err(err).Msg("failed to read meeting agenda")
+		logger.Fatal().Err(err).Msg("Failed to read meeting agenda")
 	}
 
 	logger.Info().Msg("Fetching PR statistics from GitHub")
@@ -138,14 +147,14 @@ func cloneWiki(path string, repoName string) {
 		logger.Debug().Msgf("Cloning wiki with remote %s", remote)
 		out, err := utils.RunGit(path, "clone", remote, repoName)
 		if err != nil {
-			logger.Warn().Err(err).Msgf("failed to clone coreruleset wiki: %s", out)
+			logger.Warn().Err(err).Msgf("Failed to clone coreruleset wiki: %s", out)
 			continue
 		}
 		succeeded = true
 		break
 	}
 	if !succeeded {
-		logger.Fatal().Msg("failed to clone wiki using both SSH and HTTPS; giving up")
+		logger.Fatal().Msg("Failed to clone wiki using both SSH and HTTPS; giving up")
 	}
 
 }

--- a/cmd/chore/agenda/agenda.go
+++ b/cmd/chore/agenda/agenda.go
@@ -1,6 +1,7 @@
 package agenda
 
 import (
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
 	chore "github.com/coreruleset/crs-toolchain/v2/chore/agenda"
@@ -17,8 +18,17 @@ to create the new chat agenda issue.
 Finally, the command will reset the "Agenda-Next" wiki page.`,
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			chore.Agenda()
+			printOnly, err := cmd.Flags().GetBool("print")
+			if err != nil {
+				log.Fatal().Err(err).Send()
+			}
+			chore.Agenda(printOnly)
 		},
 	}
+	buildFlags(cmd)
 	return cmd
+}
+
+func buildFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("print", false, "Print the generated agenda instead of creating an issue on GitHub")
 }


### PR DESCRIPTION
<!-- Please sign your commits: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits -->
<!-- You don't need to remove these comments, they won't be added to the PR -->
## what

Add a new `--print` flag to the `create-agenda` command that prints the generated agenda to the terminal and does not create a new issue on GitHub.


## why

Makes debugging easier and allows use of the generated contents (e.g. the generated PR list) without creating unnecessary new issues on GitHub.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--print` option to the agenda command to display the generated agenda in the terminal instead of creating a GitHub issue.
* **Bug Fixes**
  * Improved handling of agenda generation so the “print” mode bypasses issue-creation and wiki update steps.
* **Chores**
  * Updated log/warning message text for consistency in agenda-related wiki/template operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->