### PR TITLE
fix: always fail regex compare --all on drift, not just with -o github

### DIFF
--- a/cmd/regex/compare/compare.go
+++ b/cmd/regex/compare/compare.go
@@ -138,9 +138,11 @@ func performCompare(processAll bool, ctx *processors.Context, cmdContext *regexI
 		if err != nil {
 			logger.Fatal().Err(err).Msg("Failed to compare expressions")
 		}
-		if failed && cmdContext.OuterContext.Output == internal.GitHub {
-			fmt.Println("::error::All rules need to be up to date.",
-				"Please run `crs-toolchain regex update --all`")
+		if failed {
+			if cmdContext.OuterContext.Output == internal.GitHub {
+				fmt.Println("::error::All rules need to be up to date.",
+					"Please run `crs-toolchain regex update --all`")
+			}
 			return &ComparisonError{}
 		}
 	} else {

--- a/cmd/regex/compare/compare_test.go
+++ b/cmd/regex/compare/compare_test.go
@@ -149,7 +149,7 @@ id:123456`)
 	s.writeDataFile("123456.ra", "foo")
 	s.cmd.SetArgs([]string{"--all"})
 	_, err := s.cmd.ExecuteC()
-	s.Require().NoError(err)
+	s.Require().Error(err)
 
 	buffer := make([]byte, 1024)
 	_, err = read.Read(buffer)


### PR DESCRIPTION
## what

`regex compare --all` now returns a failing exit code whenever any rule's
regex is out of sync with its regex-assembly source, regardless of the
`--output` flag. Previously it only failed when `-o github` was set; in the
default text output it printed the diff but exited `0`.

The `--output github` flag now only controls whether the `::error::`
annotation is printed, matching the pattern already used by
`regex format --check` and `util renumber-tests --check`.

## why

Closes #57. `performCompare`'s `--all` branch gated the actual pass/fail
decision on the output format instead of just the message format, which is
the exact coupling #57 describes. The other two CI-check commands
(`format.go`, `renumber_tests.go`) already separate "did the check fail" from
"how do I report it," so `compare.go` was the one inconsistent case.

Production CI (`coreruleset/coreruleset`'s `lint.yaml`) always passes
`-o github`, so this doesn't change existing CI behavior — it fixes local/
manual runs of `regex compare --all` without `-o github` silently exiting `0`
on drift.

## refs

- #57
- #56 (prior related work)

## ai disclosure

- **tools used**: Claude Code
- **assisted with**: identifying the inconsistency between `compare.go` and
  the equivalent `format.go`/`renumber_tests.go` logic, drafting the fix and
  the test update
- **review performed**: confirmed production CI (`coreruleset/coreruleset`
  `lint.yaml`) always passes `-o github` so this doesn't change current CI
  behavior; reverted the fix locally and confirmed `TestCompare_Change` fails
  without it, then reinstated and confirmed it passes; ran the full test
  suite (`go test ./...`, excluding pre-existing unrelated local GPG-signing
  failures in `chore/release`) and `go vet`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for regex comparisons that fail.
  * Comparison commands now correctly return an error when regular expressions differ.
  * GitHub-specific failure annotations are applied consistently when comparisons fail.

* **Tests**
  * Updated automated coverage to verify the corrected command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->