### PR TITLE
feat: add ##!=@ retrieve marker, disallow identifier on ##!=>

### DIFF
--- a/cmd/regex/format/format_test.go
+++ b/cmd/regex/format/format_test.go
@@ -144,7 +144,7 @@ func (s *formatTestSuite) TestFormat_IndentsNestedAssembleBlocks() {
 	s.writeDataFile("123456.ra", `            ##!> assemble
     		line
 	   ##!> assemble
-	               ##!=> output
+	               ##!=@ output
 		##!=< input
 			##!> assemble
 				line2
@@ -164,7 +164,7 @@ func (s *formatTestSuite) TestFormat_IndentsNestedAssembleBlocks() {
 ##!> assemble
   line
   ##!> assemble
-    ##!=> output
+    ##!=@ output
     ##!=< input
     ##!> assemble
       line2

--- a/regex/definitions.go
+++ b/regex/definitions.go
@@ -49,9 +49,19 @@ var ProcessorEndRegex = regexp.MustCompile(`^##!<`)
 // The name is captured in group 1.
 var AssembleInputRegex = regexp.MustCompile(`^\s*##!=<\s*(.*)$`)
 
-// AssembleOutputRegex matches an output line of the assemble processor (##!=> <name>).
-// The name is captured in group 1, the optional output in group 2.
+// AssembleOutputRegex matches a concatenation-boundary line of the assemble
+// processor (##!=>). It flushes the pending alternation lines so the next
+// block concatenates instead of merging into the same alternation.
+// Any trailing content is captured in group 1; a non-empty match is invalid
+// and must be rejected by the caller, since a boundary marker takes no
+// identifier. Use AssembleRetrieveRegex (##!=@ <name>) to splice in a
+// previously stored block.
 var AssembleOutputRegex = regexp.MustCompile(`^\s*##!=>\s*(.*)$`)
+
+// AssembleRetrieveRegex matches a retrieve line of the assemble processor
+// (##!=@ <name>), splicing in a block previously stored with ##!=< <name>.
+// The name is captured in group 1.
+var AssembleRetrieveRegex = regexp.MustCompile(`^\s*##!=@\s*(\S+)\s*$`)
 
 // RuleRxRegex matches a full SecRule line with @rx.
 // Everything up to the start of the regular expression is captured in group 1,

--- a/regex/operators/assembler_test.go
+++ b/regex/operators/assembler_test.go
@@ -629,7 +629,7 @@ ab
 ##!=< myinput
 ##!<
 ##!> assemble
-##!=> myinput
+##!=@ myinput
 ##!<
 `
 	assembler := NewAssembler(s.ctx)
@@ -723,14 +723,14 @@ func (s *assemblerTestSuite) TestAssemble_ConcatenatingWithStoredInput() {
 %2f
 %5c
 ##!=< slashes
-##!=> slashes
+##!=@ slashes
 
 ##! dot patterns
 \.
 \.%00
 \.%01
 ##!=>
-##!=> slashes
+##!=@ slashes
 ##!<
 `
 	assembler := NewAssembler(s.ctx)
@@ -750,7 +750,7 @@ cd
 ##!<
 
 ##!> assemble
-##!=> globalinput1
+##!=@ globalinput1
 ##!<
 `
 	assembler := NewAssembler(s.ctx)
@@ -768,7 +768,7 @@ ab
 cd
 ##!=< globalinput2
     ##!> assemble
-    ##!=> globalinput2
+    ##!=@ globalinput2
     ##!<
 ##!<
 `
@@ -787,7 +787,7 @@ ab
 cd
   ##!=< globalinput
   ##!<
-##!=> globalinput
+##!=@ globalinput
 ##!<
 `
 	assembler := NewAssembler(s.ctx)
@@ -801,7 +801,7 @@ cd
 
 func (s *assemblerTestSuite) TestAssemble_ConcatenatingFailsWhenInputUnknown() {
 	contents := `##!> assemble
-##!=> unknown
+##!=@ unknown
 ##!<
 `
 	assembler := NewAssembler(s.ctx)
@@ -809,6 +809,19 @@ func (s *assemblerTestSuite) TestAssemble_ConcatenatingFailsWhenInputUnknown() {
 	_, err := assembler.Run(contents)
 	s.EqualError(err, "no entry in the stash for name 'unknown'")
 
+}
+
+func (s *assemblerTestSuite) TestAssemble_OutputMarkerRejectsIdentifier() {
+	contents := `##!> assemble
+ab
+##!=< stored
+##!=> stored
+##!<
+`
+	assembler := NewAssembler(s.ctx)
+
+	_, err := assembler.Run(contents)
+	s.EqualError(err, "'##!=>' no longer accepts an identifier; use '##!=@ stored' to insert a stored block")
 }
 func (s *assemblerTestSuite) TestAssemble_StoringAlternationAndConcatenation() {
 	contents := `##!> assemble
@@ -821,7 +834,7 @@ d
   ##!=< input
   ##!<
   ##!<
-##!=> input
+##!=@ input
 `
 	assembler := NewAssembler(s.ctx)
 
@@ -839,7 +852,7 @@ a
 b
   ##!=< input
   ##!<
-##!=> input
+##!=@ input
 `
 	assembler := NewAssembler(s.ctx)
 
@@ -1009,14 +1022,14 @@ func (s *assemblerTestSuite) TestAssemble_ComplexAppendWithAlternation() {
   ##!=>
 
   ##!> assemble
-    ##!=> js-prop-start
+    ##!=@ js-prop-start
     ##!> assemble
-	##!=> process-funcs
+	##!=@ process-funcs
     ##!<
     ##!> assemble
-      ##!=> process-props
+      ##!=@ process-props
     ##!<
-    ##!=> js-prop-finish
+    ##!=@ js-prop-finish
   ##!<
 ##!<`
 	assembler := NewAssembler(s.ctx)

--- a/regex/processors/assemble.go
+++ b/regex/processors/assemble.go
@@ -13,11 +13,6 @@ import (
 	"github.com/coreruleset/crs-toolchain/v2/regex"
 )
 
-const (
-	AssembleInput  string = `^\s*##!=<\s*(.*)$`
-	AssembleOutput string = `^\s*##!=>\s*(.*)$`
-)
-
 type Assemble struct {
 	proc   *Processor
 	output strings.Builder
@@ -41,17 +36,25 @@ func (a *Assemble) ProcessLine(line string) error {
 		return nil
 	}
 
-	match = regex.AssembleOutputRegex.FindStringSubmatch(line)
+	match = regex.AssembleRetrieveRegex.FindStringSubmatch(line)
 	if len(match) > 0 {
 		identifier := match[1]
 		if err := a.append(identifier); err != nil {
-			var message string
-			if identifier != "" {
-				message = fmt.Sprintf("Failed to append output with name %s", identifier)
-			} else {
-				message = "Failed to append output of previous block"
-			}
-			logger.Error().Err(err).Msg(message)
+			logger.Error().Err(err).Msgf("Failed to retrieve stored output with name %s", identifier)
+			return err
+		}
+		return nil
+	}
+
+	match = regex.AssembleOutputRegex.FindStringSubmatch(line)
+	if len(match) > 0 {
+		if identifier := strings.TrimSpace(match[1]); identifier != "" {
+			err := fmt.Errorf("'##!=>' no longer accepts an identifier; use '##!=@ %s' to insert a stored block", identifier)
+			logger.Error().Err(err).Msgf("Invalid output marker: %s", line)
+			return err
+		}
+		if err := a.append(""); err != nil {
+			logger.Error().Err(err).Msg("Failed to append output of previous block")
 			return err
 		}
 	} else {


### PR DESCRIPTION
## what

- Added a new `##!=@ <name>` marker to the `assemble` processor that splices in a block previously stored with `##!=< <name>`.
- `##!=>` (bare) keeps its existing meaning — a concatenation boundary — but now **rejects an identifier** instead of silently treating it as a splice. Passing one now fails with a clear error pointing at the replacement (`'##!=>' no longer accepts an identifier; use '##!=@ <name>' to insert a stored block`).
- Removed `AssembleInput`/`AssembleOutput` string constants in `regex/processors/assemble.go` — dead code duplicating the patterns already in `regex/definitions.go`, with no callers.
- Migrated the existing named-output test fixtures (`regex/operators/assembler_test.go`, `cmd/regex/format/format_test.go`) from `##!=> <name>` to `##!=@ <name>`, and added tests for the new marker and the new rejection error.

## why

`##!=>` currently does two different jobs depending on whether it has an identifier: bare, it's a concatenation boundary; with a name, it splices in a stashed block. Same token, two different reader-intents — you have to scan for a trailing identifier to know which one you're looking at.

Real usage in `coreruleset/coreruleset`'s `regex-assembly/` (checked via a shallow clone): 348 total `##!=>` occurrences, 265 (76%) bare, 83 (24%) named across 25 files. The bare/boundary form dominates, so it keeps the existing token; the splice case gets its own unambiguous one.

## breaking change / migration needed

This is a breaking DSL change. `coreruleset/coreruleset` currently has 83 lines across 25 `regex-assembly/*.ra` files using the old `##!=> <name>` form (e.g. `930100.ra`, `941160.ra`, `942420.ra`, a few `include/*.ra`). Those need a mechanical migration (`^(\s*)##!=>\s+(\S+)$` → `$1##!=@ $2`) before or alongside picking up this toolchain version — otherwise `regex generate`/`compare`/`update` will fail on those files with the new rejection error. Happy to open that migration PR once this lands.

## refs

- Resolves #20

## ai disclosure

- **tools used**: Claude Code
- **assisted with**: implementing the parser/processor change, migrating existing test fixtures to the new syntax, writing the new tests
- **review performed**: ran the full test suite (`go test ./...`, excluding the pre-existing unrelated local GPG-signing failures in `chore/release`), `go vet`, and manually exercised both the new `##!=@` retrieval and the new rejection error against scratch `.ra` fixtures with the built binary before and after the change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `##!=@ <name>` syntax for inserting previously stored assemble blocks.
  - Added clearer handling and reporting for invalid block references.

- **Bug Fixes**
  - Prevented output markers from being used with identifiers.
  - Updated formatting behavior so `##!=>` correctly represents an output boundary, while named block insertion uses the new retrieval syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->