### PR TITLE
fix: make chore release runnable and drop unused path argument

### DIFF
--- a/chore/release/release.go
+++ b/chore/release/release.go
@@ -32,7 +32,7 @@ const (
 
 var logger = log.With().Str("component", "release").Logger()
 
-func Release(context *context.Context, repositoryPath string, version *semver.Version, sourceRef string) {
+func Release(context *context.Context, version *semver.Version, sourceRef string) {
 	remoteName := findRemoteName(context.RootDir())
 	if remoteName == "" {
 		logger.Fatal().Msg("failed to find remote for coreruleset/coreruleset")
@@ -49,8 +49,7 @@ func Release(context *context.Context, repositoryPath string, version *semver.Ve
 
 func createAndCheckOutBranch(context *context.Context, branchName string, sourceRef string) {
 	if err := checkForCleanWorkTree(context); err != nil {
-		// FIXME
-		panic(err)
+		logger.Fatal().Err(err).Msg("cannot create release branch")
 	}
 
 	out, err := utils.RunGit(context.RootDir(), "switch", "-c", branchName, sourceRef)
@@ -70,21 +69,17 @@ func checkForCleanWorkTree(context *context.Context) error {
 	repositoryPath := context.RootDir()
 	repo, err := git.PlainOpen(repositoryPath)
 	if err != nil {
-		//FIXME
-		panic(err)
+		return fmt.Errorf("opening git repository at %s: %w", repositoryPath, err)
 	}
 	worktree, err := repo.Worktree()
 	if err != nil {
-		//FIXME
-		panic(err)
+		return fmt.Errorf("reading worktree of %s: %w", repositoryPath, err)
 	}
 	status, err := worktree.Status()
 	if err != nil {
-		//FIXME
-		panic(err)
+		return fmt.Errorf("reading status of worktree at %s: %w", repositoryPath, err)
 	}
 	if !status.IsClean() {
-		// FIXME
 		return errors.New("worktree not clean. Please stash or commit your changes first")
 	}
 	return nil

--- a/chore/release/release_test.go
+++ b/chore/release/release_test.go
@@ -34,6 +34,11 @@ func (s *choreReleaseTestSuite) SetupTest() {
 	out, err = utils.RunGit(s.repoDir, "config", "user.name", "dummy")
 	s.Require().NoError(err, string(out))
 
+	// The dummy identity above has no signing key, so a global commit.gpgsign
+	// setting would make every commit in these tests fail.
+	out, err = utils.RunGit(s.repoDir, "config", "commit.gpgsign", "false")
+	s.Require().NoError(err, string(out))
+
 	out, err = utils.RunGit(s.repoDir, "commit", "--allow-empty", "-m", "dummy")
 	s.Require().NoError(err, string(out))
 }

--- a/cmd/chore/chore_test.go
+++ b/cmd/chore/chore_test.go
@@ -91,6 +91,37 @@ func (s *choreTestSuite) TestChore_UpdateCopyright() {
 	s.Equal(buffer.String(), actual)
 }
 
+func (s *choreTestSuite) TestChore_ReleaseArgs() {
+	for _, tt := range []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{"accepts a plain version", []string{"4.1.0"}, false},
+		{"accepts a v-prefixed version", []string{"v4.1.0"}, false},
+		{"accepts a prerelease version", []string{"v4.1.0-rc1"}, false},
+		{"rejects a non-version argument", []string{"not-a-version"}, true},
+		{"rejects no arguments", []string{}, true},
+		{"rejects a leftover repository path argument", []string{".", "v4.1.0"}, true},
+	} {
+		s.Run(tt.name, func() {
+			releaseCmd, _, err := s.cmd.Find([]string{"release"})
+			s.Require().NoError(err)
+
+			err = releaseCmd.ValidateArgs(tt.args)
+			if err == nil && releaseCmd.PreRunE != nil {
+				err = releaseCmd.PreRunE(releaseCmd, tt.args)
+			}
+
+			if tt.wantErr {
+				s.Error(err)
+			} else {
+				s.NoError(err)
+			}
+		})
+	}
+}
+
 func (s *choreTestSuite) writeRulesFile(filename string, contents string) {
 	err := os.WriteFile(path.Join(s.rulesDir, filename), []byte(contents), fs.ModePerm)
 	s.Require().NoError(err)

--- a/cmd/chore/release/release.go
+++ b/cmd/chore/release/release.go
@@ -4,7 +4,7 @@
 package cmd
 
 import (
-	"os"
+	"fmt"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/spf13/cobra"
@@ -15,35 +15,29 @@ import (
 )
 
 var sourceRef string
-var repositoryPath string
 var version *semver.Version
 
 func New(cmdContext *internal.CommandContext) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "release",
+		Use:   "release <version>",
 		Short: "Create new release of CRS",
-		Args:  cobra.MatchAll(cobra.ExactArgs(2), cobra.OnlyValidArgs),
-		ValidArgs: []string{
-			"version",
-		},
+		Long: `Create a new release of CRS.
+
+The repository to operate on is the CRS directory determined by the global
+--directory flag, or the current working directory if that flag is not set.`,
+		Args: cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			repositoryPath = args[0]
-
-			if _, err := os.Stat(repositoryPath); err != nil {
-				return err
-			}
-
 			var err error
-			version, err = semver.NewVersion(args[1])
+			version, err = semver.NewVersion(args[0])
 			if err != nil {
-				return err
+				return fmt.Errorf("parsing version %q: %w", args[0], err)
 			}
 
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			rootContext := context.New(cmdContext.WorkingDirectory, cmdContext.ConfigurationFileName)
-			release.Release(rootContext, repositoryPath, version, sourceRef)
+			release.Release(rootContext, version, sourceRef)
 		},
 	}
 	buildFlags(cmd)


### PR DESCRIPTION
## What

`chore release` could not be invoked at all. It combined `cobra.OnlyValidArgs` with `ValidArgs: ["version"]`, which requires every positional argument to be the literal string `"version"`, so any real invocation failed argument validation before running:

```
$ crs-toolchain chore release . v4.1.0
Error: invalid argument "." for "crs-toolchain chore release"
```

The command also took a repository path as its first argument, but only `os.Stat`'d it. `Release` never read the parameter, and every operation used `context.RootDir()` from the global `--directory` flag. This PR drops both the argument and the parameter, so the repository comes from `--directory` or the working directory, as it does for every other command.

Usage is now:

```bash
crs-toolchain -d /path/to/coreruleset chore release v4.1.0
crs-toolchain chore release v4.1.0    # from inside the CRS repo
```

Also in this diff:

- The four `panic(err)` calls in the clean-worktree check become wrapped errors naming the repository path; the caller reports them through the logger like the rest of the package.
- A failed version parse now names the offending input: `parsing version "bogus": invalid semantic version`.
- `commit.gpgsign` is set to `false` in the release test setup. Those tests commit with a dummy identity that has no signing key, so a global `commit.gpgsign` made the whole suite fail locally.

## Testing

New table-driven test in `cmd/chore/chore_test.go` covers the accepted and rejected argument forms, including the removed path argument. Reverting the `Args` change makes it fail.

`go test ./chore/... ./cmd/...`, `go vet`, and `gofumpt` are clean.

## Note

This is a breaking change to the command's arguments, but the command could not be run successfully before, so there is no working invocation to migrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Release commands now require only a version argument and use the configured working directory.
  * Version validation errors now provide clearer details about invalid input.
  * Release failures are reported as errors instead of causing unexpected crashes.

* **Bug Fixes**
  * Release setup no longer fails when global Git commit signing is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->