### PR TITLE
fix: reject unsupported shells in completion command

### DIFF
--- a/cmd/completion/completion.go
+++ b/cmd/completion/completion.go
@@ -23,7 +23,7 @@ func createCompletionCommand() *cobra.Command {
 		Long:                  "Completion files allow you to repeatedly press tab key to show completion for all supported commands",
 		DisableFlagsInUseLine: true,
 		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
-		Args:                  cobra.MatchAll(cobra.ExactArgs(1)),
+		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
 			switch args[0] {

--- a/cmd/completion/completion_test.go
+++ b/cmd/completion/completion_test.go
@@ -33,3 +33,29 @@ func (s *completionTestSuite) TestCompletion_BashShell() {
 	s.Len(args, 1)
 	s.Equal("bash", args[0])
 }
+
+func (s *completionTestSuite) TestCompletion_Args() {
+	for _, tt := range []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{"accepts bash", []string{"bash"}, false},
+		{"accepts zsh", []string{"zsh"}, false},
+		{"accepts fish", []string{"fish"}, false},
+		{"accepts powershell", []string{"powershell"}, false},
+		{"rejects an unsupported shell", []string{"badshell"}, true},
+		{"rejects a misspelled shell", []string{"zshell"}, true},
+		{"rejects no arguments", []string{}, true},
+		{"rejects more than one shell", []string{"bash", "zsh"}, true},
+	} {
+		s.Run(tt.name, func() {
+			err := New().ValidateArgs(tt.args)
+			if tt.wantErr {
+				s.Error(err)
+			} else {
+				s.NoError(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`completion` declared `ValidArgs` but validated with `cobra.MatchAll(cobra.ExactArgs(1))`. Without `cobra.OnlyValidArgs`, `ValidArgs` only drives tab-completion and is never enforced. An unrecognized shell passed validation, fell through the `switch` without matching a case, and left `err` nil:

```
$ crs-toolchain completion badshell
$ echo $?
0
```

A typo like `zshell` produced an empty completion script and a success exit code, with nothing to indicate anything went wrong. Now:

```
$ crs-toolchain completion badshell
Error: invalid argument "badshell" for "crs-toolchain completion"
$ echo $?
1
```

## Testing

New table-driven test in `cmd/completion/completion_test.go` covers all four supported shells plus the rejected forms. Removing `cobra.OnlyValidArgs` makes it fail.

`go test ./cmd/...`, `go vet` clean.

## Note

Found while auditing argument handling across all commands after #325. The two are the same pair of knobs used wrongly in opposite directions: #325 had `OnlyValidArgs` with a placeholder in `ValidArgs`, rejecting every real argument, while this one had real values in `ValidArgs` but no `OnlyValidArgs`, accepting everything. No other command uses `OnlyValidArgs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved completion command validation to require exactly one supported shell argument.
  * Invalid, misspelled, missing, or extra arguments are now rejected consistently.

* **Tests**
  * Added coverage for valid shell options and invalid argument combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->